### PR TITLE
Add GOWIN GW1N-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ __Current support kits:__
 
 __Supported (tested) FPGA:__
 
-* Gowin [GW1N (GW1N-1, GW1NR-9)](https://www.gowinsemi.com/en/product/detail/2/) (SRAM and Flash (flash mode only tested with GW1NR-9))
+* Gowin [GW1N (GW1N-1, GW1N-4, GW1NR-9)](https://www.gowinsemi.com/en/product/detail/2/) (SRAM and Flash (flash mode only tested with GW1NR-9))
 * Lattice [MachXO3LF](http://www.latticesemi.com/en/Products/FPGAandCPLD/MachXO3.aspx) (SRAM and Flash)
 * Xilinx Artix 7 [xc7a35ti](https://www.xilinx.com/products/silicon-devices/fpga/artix-7.html) (memory and spi flash)
 * Intel Cyclone 10 LP [10CL025](https://www.intel.com/content/www/us/en/products/programmable/fpga/cyclone-10.html)

--- a/part.hpp
+++ b/part.hpp
@@ -16,6 +16,7 @@ static std::map <int, fpga_model> fpga_list = {
 	{0x612bd043, {"lattice", "MachXO3LF", "LCMX03LF-6900C"}},
 	{0x1100581b, {"Gowin", "GW1N", "GW1NR-9"}},
 	{0x0900281B, {"Gowin", "GW1N", "GW1N-1"}},
+	{0x0100381B, {"Gowin", "GW1N", "GW1N-4"}},
 };
 
 #endif


### PR DESCRIPTION
I've confirmed that OpenFPGALoader works fine with GOWIN GW1N-LV4LQ100 if I add its device code to `part.hpp`.

So please add GW1N-4 device code to support GW1N-4 devices.