### PR TITLE
make installation directory configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@
 cycloader
 openFPGALoader
 *.swp
+
+# Build directory
+build/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_FLAGS_DEBUG "-g -Wall -Wextra")
 
+include(GNUInstallDirs)
+# By default: DATA_DIR="/usr/local/share"
+add_definitions(-DDATA_DIR=\"${CMAKE_INSTALL_FULL_DATAROOTDIR}\")
+
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBFTDI REQUIRED libftdi1)
 pkg_check_modules(LIBFTDIPP REQUIRED libftdipp1)
@@ -92,5 +96,5 @@ install(TARGETS openFPGALoader DESTINATION bin)
 install(FILES 
 	test_sfl.svf
 	spiOverJtag/spiOverJtag_xc7a35.bit
-	DESTINATION share/openFPGALoader
+	DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/openFPGALoader
 )

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ To install
 ```bash
 $ sudo make install
 ```
-Currently, the install path is hardcoded to /usr/local
+The default install path is `/usr/local`, to change it, use
+`-DCMAKE_INSTALL_PREFIX=myInstallDir` in cmake invokation.
 
 ## Usage
 

--- a/src/altera.cpp
+++ b/src/altera.cpp
@@ -5,7 +5,8 @@
 
 #define IDCODE 6
 #define IRLENGTH 10
-#define BIT_FOR_FLASH "/usr/local/share/openFPGALoader/test_sfl.svf"
+// DATA_DIR is defined at compile time.
+#define BIT_FOR_FLASH (DATA_DIR "/openFPGALoader/test_sfl.svf")
 
 Altera::Altera(FtdiJtag *jtag, std::string filename, bool verbose):
 	Device(jtag, filename, verbose), _svf(_jtag, _verbose)

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -78,7 +78,8 @@ void Xilinx::program(unsigned int offset)
 
 void Xilinx::program_spi(unsigned int offset)
 {
-	std::string bitname = "/usr/local/share/openFPGALoader/spiOverJtag_";
+	// DATA_DIR is defined at compile time.
+	std::string bitname = DATA_DIR "/openFPGALoader/spiOverJtag_";
 	bitname += fpga_list[idCode()].family + ".bit";
 
 	/* first: load spi over jtag */


### PR DESCRIPTION
This removes the hardcoded paths to allow configurability (useful for packaging).

With this patch, the paths are passed as macros added at compiler invocation; in particular, the macro `DATA_DIR` is, by default, `"/usr/local/share"`. This is done by taking advantage of the GNUInstallDirs feature of CMake to locate the `.../share` directory.

In this case, this should cleaner than a generated file.