### PR TITLE
Initial Mac OS X support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,23 +107,37 @@ include_directories(
 	${LIBFTDI_INCLUDE_DIRS}
 )
 
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	find_library(LIBFTDI1STATIC libftdi1.a REQUIRED)
+	find_library(LIBUSB1STATIC libusb-1.0.a REQUIRED)
+	find_library(LIBARGPSTATIC libargp.a REQUIRED)
+	target_link_libraries(openFPGALoader ${LIBFTDI1STATIC} ${LIBUSB1STATIC} ${LIBARGPSTATIC})
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework CoreFoundation -framework IOKit")
+	link_directories(/usr/local/lib)
+	target_include_directories(openFPGALoader PRIVATE /usr/local/include)
+	set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+	set_target_properties(openFPGALoader PROPERTIES LINK_SEARCH_END_STATIC 1)
+else()
 target_link_libraries(openFPGALoader
 	${LIBUSB_LIBRARIES}
 	${LIBFTDI_LIBRARIES}
 )
-
 if(ENABLE_UDEV)
 include_directories(${LIBUDEV_INCLUDE_DIRS})
 target_link_libraries(openFPGALoader ${LIBUDEV_LIBRARIES})
 endif()
 
 if(NOT HAVE_ARGP)
-	target_link_libraries(openFPGALoader /usr/lib/libargp.a)
+	find_library(LIBARGPSTATIC libargp.a REQUIRED)
+	target_link_libraries(openFPGALoader ${LIBARGPSTATIC})
 endif()
 
 if (BUILD_STATIC)
 	set_target_properties(openFPGALoader PROPERTIES LINK_SEARCH_END_STATIC 1)
 endif()
+endif()
+
 
 # libftdi < 1.4 as no usb_addr
 if (${LIBFTDI_VERSION} VERSION_LESS 1.4)

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -331,13 +331,15 @@ bool Gowin::flashFLASH(uint8_t *data, int length)
 	 * full bitstream
 	 */
 	int buffer_length = byte_length+(6*4);
-	unsigned char buffer[byte_length+(6*4)] = {
+	unsigned char buffer[byte_length+(6*4)];
+	unsigned char bufvalues[]={
 									0x47, 0x57, 0x31, 0x4E,
 									0xff, 0xff , 0xff, 0xff,
 									0xff, 0xff , 0xff, 0xff,
 									0xff, 0xff , 0xff, 0xff,
 									0xff, 0xff , 0xff, 0xff,
 									0xff, 0xff , 0xff, 0xff};
+	memcpy(buffer, bufvalues, sizeof bufvalues);
 	memcpy(buffer+6*4, data, byte_length);
 
 	int nb_xpage = buffer_length/256;

--- a/src/spiFlash.cpp
+++ b/src/spiFlash.cpp
@@ -89,7 +89,9 @@ void SPIFlash::jtag_write_read(uint8_t cmd,
 			uint8_t *tx, uint8_t *rx, uint16_t len)
 {
 	int xfer_len = len + 1 + ((rx == NULL) ? 0 : 1);
-	uint8_t jtx[xfer_len] = {reverseByte(cmd)};
+	uint8_t jtx[xfer_len];
+	jtx[0] = reverseByte(cmd);
+	/* uint8_t jtx[xfer_len] = {reverseByte(cmd)}; */
 	uint8_t jrx[xfer_len];
 	if (tx != NULL) {
 		for (int i=0; i < len; i++)
@@ -182,11 +184,16 @@ int SPIFlash::sectors_erase(int base_addr, int size)
 	return 0;
 }
 
-int SPIFlash::write_page(int addr, uint8_t *data, int len) 
+int SPIFlash::write_page(int addr, uint8_t *data, int len)
 {
-	uint8_t tx[len+3] = {(uint8_t)(0xff & (addr >> 16)),
+	uint8_t tx[len+3];
+	tx[0] = (uint8_t)(0xff & (addr >> 16));
+	tx[1] = (uint8_t)(0xff & (addr >> 8));
+	tx[2] = (uint8_t)(addr & 0xff);
+
+	/*uint8_t tx[len+3] = {(uint8_t)(0xff & (addr >> 16)),
 								(uint8_t)(0xff & (addr >> 8)),
-								(uint8_t)(addr & 0xff)};
+								(uint8_t)(addr & 0xff)};*/
 	for (int i=0; i < len; i++) {
 		tx[i+3] = data[i];
 	}


### PR DESCRIPTION
Initial Mac implementation that includes cmake modifications and clang compilation support.

For example, one of the following errors where fixed during implementation of Mac support:

```
Scanning dependencies of target openFPGALoader
[  4%] Building CXX object CMakeFiles/openFPGALoader.dir/src/spiFlash.cpp.o
/code/github/openFPGALoader/src/spiFlash.cpp:92:14: error: variable-sized object may not be initialized
        uint8_t jtx[xfer_len] = {reverseByte(cmd)};
                    ^~~~~~~~
/code/github/openFPGALoader/src/spiFlash.cpp:187:13: error: variable-sized object may not be initialized
        uint8_t tx[len+3] = {(uint8_t)(0xff & (addr >> 16)),
                   ^~~~~
```
