### PR TITLE
add jtag frequency option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ openFPGALoader -- a program to flash cyclone10 LP FPGA
                              Gowin and ECP5 devices)
   -o, --offset=OFFSET        start offset in EEPROM
   -r, --reset                reset FPGA after operations
+  -s, --speed=SPEED          jtag frequency (Hz)
   -v, --verbose              Produce verbose output
   -?, --help                 Give this help list
       --usage                Give a short usage message

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ openFPGALoader -- a program to flash cyclone10 LP FPGA
   -c, --cable=CABLE          jtag interface
   -d, --device=DEVICE        device to use (/dev/ttyUSBx)
       --detect               detect FPGA
+      --freq=FREQ            jtag frequency (Hz)
   -f, --write-flash          write bitstream in flash (default: false, only for
                              Gowin and ECP5 devices)
       --list-boards          list all supported boards
@@ -104,7 +105,6 @@ openFPGALoader -- a program to flash cyclone10 LP FPGA
                              Gowin and ECP5 devices)
   -o, --offset=OFFSET        start offset in EEPROM
   -r, --reset                reset FPGA after operations
-  -s, --speed=SPEED          jtag frequency (Hz)
   -v, --verbose              Produce verbose output
   -?, --help                 Give this help list
       --usage                Give a short usage message


### PR DESCRIPTION
Hi,

this is another change I need for a project at work. This pull request adds a new option `--speed` / `-s`, which sets the JTAG frequency. It can deal with postfixes, so `-s 1M` or `-s 100k` both work fine.

A few miscellaneous thoughts:
- should the code responsible for parsing be moved to `parse_opt`?
- I didn't add range checks, is this taken care of down-range?

Thanks again, this tool is just so incredibly convenient when compared to Lattice's sluggish tools!
Martin