### PR TITLE
cxxopts migration and windows (MinGW) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,32 +6,36 @@ project(openFPGALoader VERSION 0.1 LANGUAGES CXX)
 
 option(BUILD_STATIC "Whether or not to build with static libraries" OFF)
 option(ENABLE_UDEV "use udev to search JTAG adapter from /dev/xx" ON)
+option(USE_PKGCONFIG "Use pkgconfig to find libraries" ON)
+option(LINK_CMAKE_THREADS "Use CMake find_package to link the threading library" OFF)
 
 ## specify the C++ standard
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS_DEBUG "-g -Wall -Wextra")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -Wall -Wextra ${CMAKE_CXX_FLAGS_DEBUG}")
 
 if (BUILD_STATIC)
-	 set(CMAKE_EXE_LINKER_FLAGS "-static-libstdc++ -static")
-	 set(BUILD_SHARED_LIBS OFF)
+	set(CMAKE_EXE_LINKER_FLAGS "-static-libstdc++ -static ${CMAKE_EXE_LINKER_FLAGS}")
+	set(BUILD_SHARED_LIBS OFF)
 endif()
 
 include(GNUInstallDirs)
 # By default: DATA_DIR="/usr/local/share"
 add_definitions(-DDATA_DIR=\"${CMAKE_INSTALL_FULL_DATAROOTDIR}\")
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(LIBFTDI REQUIRED libftdi1)
-pkg_check_modules(LIBUSB REQUIRED libusb-1.0)
+if(USE_PKGCONFIG)
+	find_package(PkgConfig REQUIRED)
+	pkg_check_modules(LIBFTDI REQUIRED libftdi1)
+	pkg_check_modules(LIBUSB REQUIRED libusb-1.0)
 
-if(ENABLE_UDEV)
-	pkg_check_modules(LIBUDEV libudev)
-	if (LIBUDEV_FOUND)
-		add_definitions(-DUSE_UDEV)
-	else()
-		message("libudev not found, disabling udev support and -d parameter")
-		set(ENABLE_UDEV OFF)
+	if(ENABLE_UDEV)
+		pkg_check_modules(LIBUDEV libudev)
+		if (LIBUDEV_FOUND)
+			add_definitions(-DUSE_UDEV)
+		else()
+			message("libudev not found, disabling udev support and -D parameter")
+			set(ENABLE_UDEV OFF)
+		endif()
 	endif()
 endif()
 
@@ -133,12 +137,17 @@ if (BUILD_STATIC)
 endif()
 endif()
 
+if (LINK_CMAKE_THREADS)
+	find_package(Threads REQUIRED)
+	target_link_libraries(openFPGALoader Threads::Threads)
+endif()
+
 
 # libftdi < 1.4 as no usb_addr
 if (${LIBFTDI_VERSION} VERSION_LESS 1.4)
-	set(CMAKE_CXX_FLAGS "-DOLD_FTDI_VERSION=1")
+	set(CMAKE_CXX_FLAGS "-DOLD_FTDI_VERSION=1 ${CMAKE_CXX_FLAGS}")
 else()
-	set(CMAKE_CXX_FLAGS "-DOLD_FTDI_VERSION=0")
+	set(CMAKE_CXX_FLAGS "-DOLD_FTDI_VERSION=0 ${CMAKE_CXX_FLAGS}")
 endif()
 
 install(TARGETS openFPGALoader DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,11 @@ target_link_libraries(openFPGALoader
 	${LIBFTDI_LIBRARIES}
 )
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+	# winsock provides ntohs
+	target_link_libraries(openFPGALoader ws2_32)
+endif()
+
 # libusb_attach_kernel_driver is only available on Linux.
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	add_definitions(-DATTACH_KERNEL)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ node). If you don't want this option, use:
 
 And if not already done, install **pkg-config**, **make** and **g++**.
 
+Alternatively you can manually specify the location of **libusb** and **libftdi1**:
+
+```-DUSE_PKGCONFIG=OFF -DLIBUSB_LIBRARIES=<path_to_libusb> -DLIBFTDI_LIBRARIES=<path_to_libftdi> -DLIBFTDI_VERSION=<version> -DCMAKE_CXX_FLAGS="-I<libusb_include_dir> -I<libftdi1_include_dir>"```
+
+You may also need to add this if you see link errors between **libusb** and **pthread**:
+
+```-DLINK_CMAKE_THREADS=ON```
+
 To build the app:
 ```bash
 $ mkdir build

--- a/src/altera.cpp
+++ b/src/altera.cpp
@@ -58,7 +58,7 @@ int Altera::idCode()
 	unsigned char rx_data[4];
 	_jtag->go_test_logic_reset();
 	_jtag->shiftIR(tx_data, NULL, IRLENGTH);
-	bzero(tx_data, 4);
+	memset(tx_data, 0, 4);
 	_jtag->shiftDR(tx_data, rx_data, 32);
 	return ((rx_data[0] & 0x000000ff) |
 		((rx_data[1] << 8) & 0x0000ff00) |

--- a/src/bitparser.cpp
+++ b/src/bitparser.cpp
@@ -2,7 +2,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>
+#ifndef _WIN32
 #include <arpa/inet.h>
+#else
+// WARNING: this will be incorrect on ARM-based windows platforms
+// that are big-endian, but the rest of this code has not been tested for
+// those platforms anyway.
+uint16_t ntohs(uint16_t netshort) {
+	return ((netshort & 0xFF) << 8) | ((netshort & 0xFF00) >> 8);
+}
+#endif
 
 using namespace std;
 

--- a/src/bitparser.cpp
+++ b/src/bitparser.cpp
@@ -5,12 +5,8 @@
 #ifndef _WIN32
 #include <arpa/inet.h>
 #else
-// WARNING: this will be incorrect on ARM-based windows platforms
-// that are big-endian, but the rest of this code has not been tested for
-// those platforms anyway.
-uint16_t ntohs(uint16_t netshort) {
-	return ((netshort & 0xFF) << 8) | ((netshort & 0xFF00) >> 8);
-}
+//for ntohs
+#include <winsock2.h>
 #endif
 
 using namespace std;

--- a/src/dirtyJtag.cpp
+++ b/src/dirtyJtag.cpp
@@ -169,7 +169,7 @@ int DirtyJtag::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 	if (tx)
 		memcpy(tx_cpy, tx, real_byte_len);
 	else
-		bzero(tx_cpy, real_byte_len);
+		memset(tx_cpy, 0, real_byte_len);
 	tx_ptr = tx_cpy;
 
 	/* first send 30 x 8 bits */
@@ -178,7 +178,7 @@ int DirtyJtag::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 		uint8_t bit_to_send = (real_bit_len > 240) ? 240 : real_bit_len;
 		uint8_t byte_to_send = (bit_to_send + 7) / 8;
 		tx_buf[1] = bit_to_send;
-		bzero(tx_buf + 2, 30);
+		memset(tx_buf + 2, 0, 30);
 		for (int i = 0; i < bit_to_send; i++)
 			if (tx_ptr[i >> 3] & (1 << (i & 0x07)))
 				tx_buf[2 + (i >> 3)] |= (0x80 >> (i & 0x07));

--- a/src/ftdiJtagBitbang.cpp
+++ b/src/ftdiJtagBitbang.cpp
@@ -74,7 +74,7 @@ void FtdiJtagBitBang::init_internal(const FTDIpp_MPSSE::mpsse_bit_config &cable,
 	setClkFreq(_clkHZ);
 
 	_in_buf = (unsigned char *)malloc(sizeof(unsigned char) * _buffer_size);
-	bzero(_in_buf, _buffer_size);
+	memset(_in_buf, 0, _buffer_size);
 	init(1, _tck_pin | _tms_pin | _tdi_pin, BITMODE_BITBANG,
 		(FTDIpp_MPSSE::mpsse_bit_config &)cable);
 	setBitmode(BITMODE_BITBANG);
@@ -162,7 +162,7 @@ int FtdiJtagBitBang::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 	if (len == 0)
 		return 0;
 	if (rx)
-		bzero(rx, len/8);
+		memset(rx, 0, len/8);
 
 	for (uint32_t i = 0, pos = 0; i < len; i++) {
 		/* keep tms or

--- a/src/ftdipp_mpsse.cpp
+++ b/src/ftdipp_mpsse.cpp
@@ -2,7 +2,6 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <termios.h>
 #include <unistd.h>
 
 #include <iostream>

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -246,7 +246,7 @@ bool Gowin::wr_rd(uint8_t cmd,
 		xfer_len = tx_len;
 
 	uint8_t xfer_tx[xfer_len], xfer_rx[xfer_len];
-	bzero(xfer_tx, xfer_len);
+	memset(xfer_tx, 0, xfer_len);
 	int i;
 	if (tx != NULL) {
 		for (i = 0; i < tx_len; i++)
@@ -335,7 +335,7 @@ bool Gowin::flashFLASH(uint8_t *data, int length)
 	int nb_iter;
 	int byte_length = length / 8;
 	uint8_t tt[39];
-	bzero(tt, 39);
+	memset(tt, 0, 39);
 
 	_jtag->go_test_logic_reset();
 

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -32,6 +32,11 @@
 
 using namespace std;
 
+#ifdef STATUS_TIMEOUT
+// defined in the Windows headers included by libftdi.h
+#undef STATUS_TIMEOUT
+#endif
+
 #define NOOP				0x02
 #define ERASE_SRAM			0x05
 #define READ_SRAM			0x03

--- a/src/jtag.cpp
+++ b/src/jtag.cpp
@@ -111,7 +111,7 @@ void Jtag::init_internal(cable_t &cable, const string &dev,
 	}
 
 	_tms_buffer = (unsigned char *)malloc(sizeof(unsigned char) * _tms_buffer_size);
-	bzero(_tms_buffer, _tms_buffer_size);
+	memset(_tms_buffer, 0, _tms_buffer_size);
 }
 
 int Jtag::detectChain(vector<int> &devices, int max_dev)
@@ -164,7 +164,7 @@ int Jtag::flushTMS(bool flush_buffer)
 		ret = _jtag->writeTMS(_tms_buffer, _num_tms, flush_buffer);
 
 		/* reset buffer and number of bits */
-		bzero(_tms_buffer, _tms_buffer_size);
+		memset(_tms_buffer, 0, _tms_buffer_size);
 		_num_tms = 0;
 	} else if (flush_buffer) {
 		_jtag->flush();

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -614,7 +614,7 @@ bool Lattice::wr_rd(uint8_t cmd,
 
 	uint8_t xfer_tx[xfer_len];
 	uint8_t xfer_rx[xfer_len];
-	bzero(xfer_tx, xfer_len);
+	memset(xfer_tx, 0, xfer_len);
 	int i;
 	if (tx != NULL) {
 		for (i = 0; i < tx_len; i++)
@@ -793,7 +793,7 @@ bool Lattice::Verify(std::vector<std::string> data, bool unlock)
 	tx_buf[0] = REG_CFG_FLASH;
 	_jtag->shiftIR(tx_buf, NULL, 8, Jtag::PAUSE_IR);
 
-	bzero(tx_buf, 16);
+	memset(tx_buf, 0, 16);
 	bool failure = false;
 	ProgressBar progress("Verifying", data.size(), 50);
 	for (size_t line = 0;  line< data.size(); line++) {
@@ -826,7 +826,7 @@ uint64_t Lattice::readFeaturesRow()
 	uint8_t tx_buf[8];
 	uint8_t rx_buf[8];
 	uint64_t reg = 0;
-	bzero(tx_buf, 8);
+	memset(tx_buf, 0, 8);
 	wr_rd(READ_FEATURE_ROW, tx_buf, 8, rx_buf, 8);
 	for (int i = 0; i < 8; i++)
 		reg |= ((uint64_t)rx_buf[i] << (i*8));

--- a/src/latticeBitParser.cpp
+++ b/src/latticeBitParser.cpp
@@ -17,7 +17,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <arpa/inet.h>
 
 #include <algorithm>
 #include <functional>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,9 +185,9 @@ int main(int argc, char **argv)
 	delete(jtag);
 }
 
-// parse double from string in enginerring notation
+// parse double from string in engineering notation
 // can deal with postfixes k and m, add more when required
-static error_t parse_eng(string arg, double *dst) {
+static int parse_eng(string arg, double *dst) {
 	try {
 		size_t end;
 		double base = stod(arg, &end);
@@ -209,7 +209,7 @@ static error_t parse_eng(string arg, double *dst) {
 			return EINVAL;
 		}
 	} catch (...) {
-		cerr << "error : speed: invaild format" << endl;
+		cerr << "error : speed: invalid format" << endl;
 		return EINVAL;
 	}
 }


### PR DESCRIPTION
As discussed in #38 - the change to cxxopts instead of libargp plus some other minor changes enables us to pretty easily build this for Windows too!
