### PR TITLE
Add FTDI channel selection command line argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ openFPGALoader -- a program to flash cyclone10 LP FPGA
   -b, --board=BOARD          board name, may be used instead of cable
   -c, --cable=CABLE          jtag interface
   -d, --device=DEVICE        device to use (/dev/ttyUSBx)
+      --ftdi-channel=CHANNEL FTDI chip channel number (channels 0-3 map to A-D)
       --detect               detect FPGA
       --freq=FREQ            jtag frequency (Hz)
   -f, --write-flash          write bitstream in flash (default: false, only for

--- a/src/cable.hpp
+++ b/src/cable.hpp
@@ -22,6 +22,20 @@ typedef struct {
 	FTDIpp_MPSSE::mpsse_bit_config config;
 } cable_t;
 
+inline int ftdi_update_channel(cable_t &cable, unsigned int channel_num)
+{
+	int mapping[] = {INTERFACE_A,INTERFACE_B, INTERFACE_C, INTERFACE_D};
+	
+	if (cable.type != MODE_FTDI_SERIAL && cable.type != MODE_FTDI_BITBANG)
+		return -1;
+
+	if (channel_num > 3)
+		return -2;
+
+	cable.config.interface = mapping[channel_num];
+	return 0;
+}
+
 static std::map <std::string, cable_t> cable_list = {
 	// last 4 bytes are ADBUS7-0 value, ADBUS7-0 direction, ACBUS7-0 value, ACBUS7-0 direction
 	// some cables requires explicit values on some of the I/Os

--- a/src/cable.hpp
+++ b/src/cable.hpp
@@ -22,20 +22,6 @@ typedef struct {
 	FTDIpp_MPSSE::mpsse_bit_config config;
 } cable_t;
 
-inline int ftdi_update_channel(cable_t &cable, unsigned int channel_num)
-{
-	int mapping[] = {INTERFACE_A,INTERFACE_B, INTERFACE_C, INTERFACE_D};
-	
-	if (cable.type != MODE_FTDI_SERIAL && cable.type != MODE_FTDI_BITBANG)
-		return -1;
-
-	if (channel_num > 3)
-		return -2;
-
-	cable.config.interface = mapping[channel_num];
-	return 0;
-}
-
 static std::map <std::string, cable_t> cable_list = {
 	// last 4 bytes are ADBUS7-0 value, ADBUS7-0 direction, ACBUS7-0 value, ACBUS7-0 direction
 	// some cables requires explicit values on some of the I/Os


### PR DESCRIPTION
Some boards have FTDI JTAG connected to the FPGA on different channel.
It's helpful to be able to provide the channel on command line.