### PR TITLE
limit the progressBar update rate to 5 per second. This speeds up loa…

### DIFF
--- a/src/progressBar.cpp
+++ b/src/progressBar.cpp
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include "time.h"
 #include "progressBar.hpp"
 #include "display.hpp"
 
@@ -24,9 +25,15 @@ ProgressBar::ProgressBar(std::string mess, int maxValue, int progressLen):
 		_mess(mess), _maxValue(maxValue), _progressLen(progressLen)
 {
 }
-
-void ProgressBar::display(int value)
+static time_t last_time; 
+void ProgressBar::display(int value, char force)
 {
+	clock_t this_time = clock();
+	if (!force && ((((float)(this_time - last_time))/CLOCKS_PER_SEC) < 0.2))
+	{
+		return;
+	}
+	last_time = this_time;
 	float percent = ((float)value * 100.0f)/(float)_maxValue;
 	float nbEq = (percent * (float) _progressLen)/100.0f;
 
@@ -41,13 +48,13 @@ void ProgressBar::display(int value)
 }
 void ProgressBar::done()
 {
-	display(_maxValue);
+	display(_maxValue, true);
 	//fprintf(stderr, "\nDone\n");
 	printSuccess("\nDone");
 }
 void ProgressBar::fail()
 {
-	display(_maxValue);
+	display(_maxValue, true);
 	//fprintf(stderr, "\nDone\n");
 	printError("\nFail");
 }

--- a/src/progressBar.cpp
+++ b/src/progressBar.cpp
@@ -17,15 +17,14 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "time.h"
 #include "progressBar.hpp"
 #include "display.hpp"
 
 ProgressBar::ProgressBar(std::string mess, int maxValue, int progressLen):
 		_mess(mess), _maxValue(maxValue), _progressLen(progressLen)
 {
+	last_time = clock();
 }
-static time_t last_time; 
 void ProgressBar::display(int value, char force)
 {
 	clock_t this_time = clock();

--- a/src/progressBar.hpp
+++ b/src/progressBar.hpp
@@ -17,7 +17,7 @@
 
 #ifndef PROGRESSBARE_HPP
 #define PROGRESSBARE_HPP
-
+#include <time.h>
 #include <iostream>
 
 class ProgressBar {
@@ -30,6 +30,7 @@ class ProgressBar {
 		std::string _mess;
 		int _maxValue;
 		int _progressLen;
+		clock_t last_time; //records the time of last progress bar update 
 };
 
 #endif

--- a/src/progressBar.hpp
+++ b/src/progressBar.hpp
@@ -23,7 +23,7 @@
 class ProgressBar {
 	public:
 		ProgressBar(std::string mess, int maxValue, int progressLen);
-		void display(int value);
+		void display(int value, char force = 0);
 		void done();
 		void fail();
 	private:


### PR DESCRIPTION
Hello! 
I would like to submit this small change to the progress bar. It limit its update rate to 5 updates a second. This does speed up the loading of small bin files because the terminal takes time to redisplay the bar. 
Thanks a lot. 
Patrick.