### PR TITLE
add support for kintex xc7k325t

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ __Supported (tested) FPGA:__
 * Lattice [MachXO3D](http://www.latticesemi.com/en/Products/FPGAandCPLD/MachXO3D.aspx) (SRAM and Flash)
 * Lattice [ECP5 (25F, 5G 85F](http://www.latticesemi.com/Products/FPGAandCPLD/ECP5) (SRAM and Flash)
 * Lattice [ECP5 (25F, 5G 85F, CrossLink-NX (LIFCL-40)](https://www.latticesemi.com/en/Products/FPGAandCPLD/CrossLink-NX) (SRAM and Flash)
+* Xilinx Kintex 7 [xc7k325t](https://www.xilinx.com/products/silicon-devices/fpga/kintex-7.html#productTable) (SRAM)
 * Xilinx Artix 7 [xc7a35ti, xc7a50t, xc7a100t, xc7a200t](https://www.xilinx.com/products/silicon-devices/fpga/artix-7.html) (memory and spi flash)
 * Xilinx Spartan 6 [xc6slx45](https://www.xilinx.com/products/silicon-devices/fpga/spartan-6.html) (memory)
 * Xilinx Spartan 7 [xc7s15, xc7s25, xc7s50](https://www.xilinx.com/products/silicon-devices/fpga/spartan-7.html) (memory (all) and spi flash (xc7s50))

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -87,6 +87,7 @@ static std::map <std::string, target_cable_t> board_list = {
 	JTAG_BOARD("acornCle215", "",          0, 0),
 	JTAG_BOARD("arty",       "digilent",   0, 0),
 	JTAG_BOARD("nexysVideo", "digilent_b", 0, 0),
+	JTAG_BOARD("kc705", "digilent", 0, 0),
 	JTAG_BOARD("colorlight", "",           0, 0),
 	JTAG_BOARD("crosslinknx_evn", "ft2232", 0, 0),
 	JTAG_BOARD("cyc1000",    "ft2232",     0, 0),

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -13,6 +13,8 @@ typedef struct {
 static std::map <int, fpga_model> fpga_list = {
 	{0x0a014c35, {"anlogic", "eagle s20", "EG4S20BG256"}},
 
+	{0x43651093, {"xilinx", "kintex7", "xc7k325t"}},
+
 	{0x0362D093, {"xilinx", "artix a7 35t", "xc7a35"}},
 	{0x0362c093, {"xilinx", "artix a7 50t",  "xc7a50t"}},
 	{0x13631093, {"xilinx", "artix a7 100t", "xc7a100"}},


### PR DESCRIPTION
add support for kintex xc7k325t, found for example on the KC705 dev board.

While I've not tested it yet, I'm sure flashing the QSPI works as well. Only problem is that a licence in required to generate a bitstream for this device family. So it's probably a good idea to partition the makefile in devices that can be used with the free version, and then the others, or something similar.