### PR TITLE
Add Orbtrace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ __Supported cables:__
 * anlogic JTAG adapter
 * [digilent_hs2](https://store.digilentinc.com/jtag-hs2-programming-cable/): jtag programmer cable from digilent
 * [cmsisdap](https://os.mbed.com/docs/mbed-os/v6.11/debug-test/daplink.html): ARM CMSIS DAP protocol interface (hid only)
+* [Orbtrace](https://github.com/orbcode/orbtrace): Open source FPGA-based debug and trace interface
 * [DFU (Device Firmware Upgrade)](http://www.usb.org/developers/docs/devclass_docs/DFU_1.1.pdf): USB device compatible with DFU protocol
 * [DirtyJTAG](https://github.com/jeanthom/DirtyJTAG): JTAG probe firmware for STM32F1
   (Best to use release (1.4 or newer) or limit the --freq to 600000 with older releases. New version https://github.com/jeanthom/DirtyJTAG/tree/dirtyjtag2 is also supported)

--- a/src/cable.hpp
+++ b/src/cable.hpp
@@ -45,6 +45,7 @@ static std::map <std::string, cable_t> cable_list = {
 	{"ft232RL",      {MODE_FTDI_BITBANG, {0x0403, 0x6001, INTERFACE_A, 0x08, 0x0B, 0x08, 0x0B}}},
 	{"ft4232",       {MODE_FTDI_SERIAL,  {0x0403, 0x6011, INTERFACE_A, 0x08, 0x0B, 0x08, 0x0B}}},
 	{"ecpix5-debug", {MODE_FTDI_SERIAL,  {0x0403, 0x6010, INTERFACE_A, 0xF8, 0xFB, 0xFF, 0xFF}}},
+	{"orbtrace",     {MODE_CMSISDAP,     {0x1209, 0x3443, 0,           0,    0,    0,    0   }}},
 	{"tigard",       {MODE_FTDI_SERIAL,  {0x0403, 0x6010, INTERFACE_B, 0x08, 0x3B, 0x00, 0x00}}},
 	{"usb-blaster",  {MODE_USBBLASTER,   {0x09Fb, 0x6001, 0,           0,    0,    0,    0   }}},
 	{"usb-blasterII",{MODE_USBBLASTER,   {0x09Fb, 0x6810, 0,           0,    0,    0,    0   }}},

--- a/src/cmsisDAP.cpp
+++ b/src/cmsisDAP.cpp
@@ -110,14 +110,8 @@ CmsisDAP::CmsisDAP(int vid, int pid, bool verbose):_verbose(verbose),
 	 */
 	devs = hid_enumerate(vid, pid);
 
-	/* for all HID devices extracts only
-	 * ones with a product_string containing the string "CMSIS-DAP"
-	 */
 	for (cur_dev = devs; NULL != cur_dev; cur_dev = cur_dev->next) {
-		if (NULL != cur_dev->product_string &&
-				wcsstr(cur_dev->product_string, L"CMSIS-DAP")) {
-			dev_found.push_back(cur_dev);
-		}
+		dev_found.push_back(cur_dev);
 	}
 
 	/* no devices: stop */


### PR DESCRIPTION
Hi, [Orbtrace](https://github.com/orbcode/orbtrace) is an open source FPGA-based debug and trace interface with CMSIS-DAP support. Attached patches makes openFPGALoader work with it.

The second patch removes the product string check. CMSIS-DAP specification states that the string «CMSIS-DAP» can either be placed in the product string or the interface string for the actual interface, and since Orbtrace is a composite device with both CMSIS-DAP v1 (HID) and v2 (bulk) interfaces being optional features, presence is only being announced by each interface string.

Since hidapi doesn't expose interface strings, there's no easy way to check them, and since we're currently only calling `hid_enumerate()` with the VID/PID combination for the selected cable anyway, I propose just removing all string checking for the time being.

To later support arbitrary CMSIS-DAP devices without having to whitelist each VID/PID combination, I suggest using libusb to enumerate devices, checking both product and interface strings, before switching to hidapi to open the interface if a v1 interface is selected.

```
zyp@rin build $ ./openFPGALoader -c orbtrace --detect 
write to ram
Found 1 compatible device:
	0x1209 0x3443 Orbtrace
index 0:
	idcode 0x41112043
	manufacturer lattice
	model  LFE5U-45
	family ECP5
	irlength 8
```

![IMG_20210622_232951](https://user-images.githubusercontent.com/153099/123006743-6eb91a80-d3b8-11eb-81db-70ddcd275931.jpeg)
