### PR TITLE
Add board specific default frequency

### DIFF
--- a/src/board.hpp
+++ b/src/board.hpp
@@ -80,34 +80,38 @@ typedef struct {
 	uint16_t mode;           /*! communication type (JTAG or SPI) */
 	jtag_pins_conf_t jtag_pins_config; /*! for bitbang, provide struct with pins value */
 	spi_pins_conf_t spi_pins_config; /*! for SPI, provide struct with pins value */
+	uint32_t default_freq;   /* Default clock speed: 0 = use cable default */
 } target_board_t;
 
-#define JTAG_BOARD(_name, _fpga_part, _cable, _rst, _done) \
-	{_name, {"", _cable, _fpga_part, _rst, _done, COMM_JTAG, {}, {}}}
+#define CABLE_DEFAULT 0
+#define CABLE_MHZ(_m) ((_m) * 1000000)
+
+#define JTAG_BOARD(_name, _fpga_part, _cable, _rst, _done, _freq) \
+	{_name, {"", _cable, _fpga_part, _rst, _done, COMM_JTAG, {}, {}, _freq}}
 #define JTAG_BITBANG_BOARD(_name, _fpga_part, _cable, _rst, _done, _tms, _tck, _tdi, _tdo) \
-	{_name, {"", _cable, _fpga_part, _rst, _done, COMM_JTAG, { _tms, _tck, _tdi, _tdo }, {}}}
+	{_name, {"", _cable, _fpga_part, _rst, _done, COMM_JTAG, { _tms, _tck, _tdi, _tdo }, {}, 0}}
 #define SPI_BOARD(_name, _manufacturer, _cable, _rst, _done, _cs, _sck, _si, _so, _holdn, _wpn) \
 	{_name, {_manufacturer, _cable, "", _rst, _done, COMM_SPI, {}, \
-		{_cs, _sck, _so, _si, _holdn, _wpn}}}
+		{_cs, _sck, _so, _si, _holdn, _wpn}, 0}}
 #define DFU_BOARD(_name, _fpga_part, _cable) \
-	{_name, {"", _cable, _fpga_part, 0, 0, COMM_DFU, {}, {}}}
+	{_name, {"", _cable, _fpga_part, 0, 0, COMM_DFU, {}, {}, 0}}
 
 static std::map <std::string, target_board_t> board_list = {
-	JTAG_BOARD("acornCle215",     "xc7a200tsbg484", "",         0, 0),
-	JTAG_BOARD("alchitry_au",     "xc7a35tftg256",  "ft2232",   0, 0),
-	JTAG_BOARD("arty",            "xc7a35tcsg324",  "digilent", 0, 0),
-	JTAG_BOARD("basys3",          "xc7a35tcpg236",  "digilent", 0, 0),
-	JTAG_BOARD("nexysVideo",      "xc7a200tsbg484", "digilent_b", 0, 0),
-	JTAG_BOARD("kc705",           "", "digilent", 0, 0),
-	JTAG_BOARD("colorlight",      "", "",           0, 0),
-	JTAG_BOARD("colorlight-i5",   "", "cmsisdap", 0, 0),
-	JTAG_BOARD("crosslinknx_evn", "", "ft2232", 0, 0),
-	JTAG_BOARD("cyc1000",         "10cl025256", "ft2232",     0, 0),
-	JTAG_BOARD("de0",             "", "usb-blaster",0, 0),
-	JTAG_BOARD("de0nano",         "ep4ce2217", "usb-blaster",0, 0),
-	JTAG_BOARD("de0nanoSoc",      "", "usb-blasterII",0, 0),
-	JTAG_BOARD("de10nano",        "", "usb-blasterII",0, 0),
-	JTAG_BOARD("ecp5_evn",        "", "ft2232",     0, 0),
+	JTAG_BOARD("acornCle215",     "xc7a200tsbg484", "",         0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("alchitry_au",     "xc7a35tftg256",  "ft2232",   0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("arty",            "xc7a35tcsg324",  "digilent", 0, 0, CABLE_MHZ(10)),
+	JTAG_BOARD("basys3",          "xc7a35tcpg236",  "digilent", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("nexysVideo",      "xc7a200tsbg484", "digilent_b", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("kc705",           "", "digilent", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("colorlight",      "", "",           0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("colorlight-i5",   "", "cmsisdap", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("crosslinknx_evn", "", "ft2232", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("cyc1000",         "10cl025256", "ft2232",     0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("de0",             "", "usb-blaster",0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("de0nano",         "ep4ce2217", "usb-blaster",0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("de0nanoSoc",      "", "usb-blasterII",0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("de10nano",        "", "usb-blasterII",0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("ecp5_evn",        "", "ft2232",     0, 0, CABLE_DEFAULT),
 	SPI_BOARD("fireant",              "efinix", "ft232",
 			DBUS4, DBUS5, DBUS3, DBUS0, DBUS1, DBUS2, DBUS6, 0),
 	DFU_BOARD("fomu",             "", "dfu"            ),
@@ -116,27 +120,27 @@ static std::map <std::string, target_board_t> board_list = {
 			DBUS7, DBUS6,
 			DBUS4, DBUS0, DBUS1, DBUS2,
 			0, 0),
-	JTAG_BOARD("machXO2EVN",      "", "ft2232",     0, 0),
-	JTAG_BOARD("machXO3SK",       "", "ft2232",     0, 0),
-	JTAG_BOARD("machXO3EVN",      "", "ft2232",     0, 0),
-	JTAG_BOARD("licheeTang",      "", "anlogicCable", 0, 0),
+	JTAG_BOARD("machXO2EVN",      "", "ft2232",     0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("machXO3SK",       "", "ft2232",     0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("machXO3EVN",      "", "ft2232",     0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("licheeTang",      "", "anlogicCable", 0, 0, CABLE_DEFAULT),
 	/* left for backward compatibility, use tec0117 instead */
-	JTAG_BOARD("littleBee",       "", "ft2232",     0, 0),
-	JTAG_BOARD("spartanEdgeAccelBoard", "", "",0, 0),
-	JTAG_BOARD("pipistrello",     "xc6slx45csg324", "ft2232", 0, 0),
-	JTAG_BOARD("minispartan6",    "", "ft2232",    0, 0),
+	JTAG_BOARD("littleBee",       "", "ft2232",     0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("spartanEdgeAccelBoard", "", "",0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("pipistrello",     "xc6slx45csg324", "ft2232", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("minispartan6",    "", "ft2232",    0, 0, CABLE_DEFAULT),
 	DFU_BOARD("orangeCrab",       "", "dfu"            ),
-	JTAG_BOARD("qmtechCycloneV",  "5ce223", "",     0, 0),
-	JTAG_BOARD("runber",          "", "ft232",      0, 0),
-	JTAG_BOARD("tangnano",        "", "ft2232",     0, 0),
-	JTAG_BOARD("tec0117",         "", "ft2232",     0, 0),
+	JTAG_BOARD("qmtechCycloneV",  "5ce223", "",     0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("runber",          "", "ft232",      0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("tangnano",        "", "ft2232",     0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("tec0117",         "", "ft2232",     0, 0, CABLE_DEFAULT),
 	JTAG_BITBANG_BOARD("ulx2s",   "", "ft232RL", 0, 0, FT232RL_RI, FT232RL_DSR, FT232RL_CTS, FT232RL_DCD),
 	JTAG_BITBANG_BOARD("ulx3s",   "", "ft231X",  0, 0, FT232RL_DCD, FT232RL_DSR, FT232RL_RI, FT232RL_CTS),
-	JTAG_BOARD("ecpix5",          "", "ecpix5-debug", 0, 0),
-	JTAG_BOARD("xtrx",            "xc7a50tcpg236", ""            , 0, 0),
+	JTAG_BOARD("ecpix5",          "", "ecpix5-debug", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("xtrx",            "xc7a50tcpg236", ""            , 0, 0, CABLE_DEFAULT),
 	SPI_BOARD("xyloni_spi",       "efinix", "efinix_spi",
 			DBUS4 | DBUS7, DBUS5, DBUS3, DBUS0, DBUS1, DBUS2, DBUS6, 0),
-	JTAG_BOARD("zedboard",        "xc7z020-clg484", "digilent_hs2", 0, 0),
+	JTAG_BOARD("zedboard",        "xc7z020-clg484", "digilent_hs2", 0, 0, CABLE_DEFAULT),
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,8 @@
 #include "rawParser.hpp"
 #include "xilinx.hpp"
 
+#define DEFAULT_FREQ 	6000000
+
 using namespace std;
 
 struct arguments {
@@ -70,7 +72,7 @@ int main(int argc, char **argv)
 
 	/* command line args. */
 	struct arguments args = {0, false, false, false, 0, "", "", "-", "", -1,
-			6000000, "-", false, false, false, false, Device::WR_SRAM, false,
+			DEFAULT_FREQ, "-", false, false, false, false, Device::WR_SRAM, false,
 			false, false, "", "", "", -1, 0};
 	/* parse arguments */
 	try {
@@ -127,7 +129,7 @@ int main(int argc, char **argv)
 			args.fpga_part = board->fpga_part;
 
 		/* Some boards can override the default clock speed */
-		if (board->default_freq != CABLE_DEFAULT)
+		if (board->default_freq != CABLE_DEFAULT && freq == DEFAULT_FREQ)
 			freq = board->default_freq;
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,6 +95,8 @@ int main(int argc, char **argv)
 		board = &(board_list[args.board]);
 	}
 
+	uint32_t freq = args.freq;
+
 	/* if a board name is specified try to use this to determine cable */
 	if (board) {
 		/* set pins config (only when user has not already provided
@@ -123,6 +125,10 @@ int main(int argc, char **argv)
 			printInfo("Board default fpga part overridden with " + args.fpga_part);
 		else if (!board->fpga_part.empty() && args.fpga_part.empty())
 			args.fpga_part = board->fpga_part;
+
+		/* Some boards can override the default clock speed */
+		if (board->default_freq != CABLE_DEFAULT)
+			freq = board->default_freq;
 	}
 
 	if (args.cable[0] == '-') { /* if no board and no cable */
@@ -161,7 +167,7 @@ int main(int argc, char **argv)
 		spi_pins_conf_t pins_config = board->spi_pins_config;
 
 		try {
-			spi = new FtdiSpi(cable.config, pins_config, args.freq, args.verbose > 0);
+			spi = new FtdiSpi(cable.config, pins_config, freq, args.verbose > 0);
 		} catch (std::exception &e) {
 			printError("Error: Failed to claim cable");
 			return EXIT_FAILURE;
@@ -277,7 +283,7 @@ int main(int argc, char **argv)
 	Jtag *jtag;
 	try {
 		jtag = new Jtag(cable, &pins_config, args.device, args.ftdi_serial,
-				args.freq, false, args.probe_firmware);
+				freq, false, args.probe_firmware);
 	} catch (std::exception &e) {
 		printError("JTAG init failed with: " + string(e.what()));
 		return EXIT_FAILURE;


### PR DESCRIPTION
As some boards are known to run with higher TCK frequencies, allow a board-specific default to be specified in the board configuration table.

The only board affected by this change is the Digilent Arty which now defaults to 10MHz JTAG clock (which I tested), but the mechanism is generic and other boards can be modified as and when required.

The user can still override the frequency from the command line.