### PR TITLE
ci: use eine/tip to release artifacts

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -194,3 +194,24 @@ jobs:
       run: |
         openFPGALoader --help
         openFPGALoader --detect || true
+
+
+  Release:
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
+    needs: [ lin-test, win-test ]
+    runs-on: ubuntu-latest
+    name: '📦 Release'
+    steps:
+
+    - name: '📥 Download artifacts'
+      uses: actions/download-artifact@v2
+      with:
+        path: artifact
+
+    # Tagged: create a pre-release or a release (semver)
+    # Untagged: update the assets of pre-release 'nightly'
+    - uses: eine/tip@master
+      with:
+        token: ${{ github.token }}
+        tag: 'nightly'
+        files: artifact/**/*


### PR DESCRIPTION
Artifacts don't have a fixed URL and users need to login into GitHub in order to download them. Conversely, release assets do have a fixed URL and can be downloaded without login. Hence, this PR uses an action ([eine/tip](https://github.com/eine/tip)) for uploading the artifacts as assets of pre-release 'nightly'.

Note that it will only upload them if all jobs are successful, and only on branch 'master' or on tagged commits.

Actually, it works for tagged releases too. On untagged commits, the assets in 'nightly' will be updated. On tagged commits, a release will be created; it uses semver to decide whether it needs to be a release or a pre-release.