### PR TITLE
Mpsse toggle

### DIFF
--- a/src/ftdiJtagMPSSE.cpp
+++ b/src/ftdiJtagMPSSE.cpp
@@ -168,20 +168,27 @@ int FtdiJtagMPSSE::toggleClk(uint8_t tms, uint8_t tdi, uint32_t clk_len)
 
 	if (_ftdi->type == TYPE_2232H || _ftdi->type == TYPE_4232H ||
 				_ftdi->type == TYPE_232H) {
-		uint8_t buf[] = {static_cast<uint8_t>(0x8f), 0, 0};
-		if (clk_len > 8) {
-			buf[1] = ((len / 8)     ) & 0xff;
-			buf[2] = ((len / 8) >> 8) & 0xff;
-			mpsse_store(buf, 3);
-			len %= 8;
+	    uint8_t buf[] = {static_cast<uint8_t>(0x8f), 0, 0};
+	    while (len) {
+		unsigned int chunk = len;
+		if (chunk > 0x10000 * 8)
+		    chunk = 0x10000 * 8;
+		if (chunk  > 8) {
+		    unsigned cycles8 = chunk / 8;
+		    len -= cycles8 * 8;
+		    cycles8 --;
+		    buf[1] = ((cycles8)     ) & 0xff;
+		    buf[2] = ((cycles8) >> 8) & 0xff;
+		    mpsse_store(buf, 3);
 		}
-
-		if (len > 0) {
-			buf[0] = 0x8E;
-			buf[1] = len - 1;
-			mpsse_store(buf, 2);
+		if (len && len < 9) {
+		    buf[0] = 0x8E;
+		    buf[1] = len - 1;
+		    mpsse_store(buf, 2);
+		    len = 0;
 		}
-		ret = clk_len;
+	    }
+	    ret = clk_len;
 	} else {
 		int byteLen = (len+7)/8;
 		uint8_t buf_tms[byteLen];

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -42,7 +42,7 @@ static std::map <int, fpga_model> fpga_list = {
 	{0x09602093, {"xilinx", "xc9500xl", "xc9536xl",  8}},
 	{0x09604093, {"xilinx", "xc9500xl", "xc9572xl",  8}},
 	{0x09608093, {"xilinx", "xc9500xl", "xc95144xl", 8}},
-	{0x09616093, {"xilinx", "xc9500xl", "xc95188xl", 8}},
+	{0x09616093, {"xilinx", "xc9500xl", "xc95288xl", 8}},
 
 	{0x05044093, {"xilinx", "xcf",      "xcf01s",    8}},
 	{0x05045093, {"xilinx", "xcf",      "xcf02s",    8}},


### PR DESCRIPTION
MPSSE can only do 8 * 0x1000 togles in one chunk. Break up larger requests. E.g. used in theXC95 algorithms.