### PR TITLE
ci: rm 'max-parallel'

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -31,7 +31,6 @@ jobs:
   lin-build:
     strategy:
       fail-fast: false
-      max-parallel: 4
       matrix:
         os:
         - 18
@@ -92,7 +91,6 @@ jobs:
     needs: lin-build
     strategy:
       fail-fast: false
-      max-parallel: 4
       matrix:
         os:
         - 18


### PR DESCRIPTION
Since this repo is public and open source, there is no need to limit the maximum number of parallel jobs. If more jobs are required, additional jobs will be queued and executed automatically. Nonetheless, the limit is 18-20 concurrent jobs, which is not frequent in this repo.