### PR TITLE
ci/win: use option 'pacboy' of setup-msys2

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -130,10 +130,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { icon: '⬛', sys: mingw32, env: i686 }
-          - { icon: '🟦', sys: mingw64, env: x86_64 }
-          - { icon: '🟨', sys: ucrt64,  env: ucrt-x86_64 }  # Experimental!
-          - { icon: '🟧', sys: clang64, env: clang-x86_64 } # Experimental!
+          - { icon: '⬛', sys: mingw32 }
+          - { icon: '🟦', sys: mingw64 }
+          - { icon: '🟨', sys: ucrt64  } # Experimental!
+          - { icon: '🟧', sys: clang64 } # Experimental!
     name: '🚧${{ matrix.icon }} ${{ matrix.sys }} | makepkg'
     defaults:
       run:
@@ -160,7 +160,7 @@ jobs:
           git
           base-devel
           tree
-          mingw-w64-${{ matrix.env }}-toolchain
+        pacboy: toolchain:p
 
     - name: '🚧 Build package'
       run: |
@@ -171,7 +171,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.sys }}-openFPGALoader
-        path: scripts/msys2/*${{ matrix.env }}*.zst
+        path: scripts/msys2/*.zst
 
     - name: '🔍 Show package content'
       run: |
@@ -188,10 +188,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { icon: '⬛', sys: mingw32, env: i686 }
-          - { icon: '🟦', sys: mingw64, env: x86_64 }
-          - { icon: '🟨', sys: ucrt64,  env: ucrt-x86_64 }  # Experimental!
-          - { icon: '🟧', sys: clang64, env: clang-x86_64 } # Experimental!
+          - { icon: '⬛', sys: mingw32 }
+          - { icon: '🟦', sys: mingw64 }
+          - { icon: '🟨', sys: ucrt64  } # Experimental!
+          - { icon: '🟧', sys: clang64 } # Experimental!
     name: '🚦${{ matrix.icon }} ${{ matrix.sys }} | test'
     defaults:
       run:


### PR DESCRIPTION
In v2.6.0 of Action setup-msys2, option 'pacboy' was added. That allows to slightly cleanup the syntax used in the CI workflow.