### PR TITLE
ci/win: add job 'win-jobs'

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -124,16 +124,32 @@ jobs:
         openFPGALoader --detect || true
 
 
+  win-jobs:
+    name: ⬜ Generate list of MSYS2 jobs
+    runs-on: ubuntu-latest
+    outputs:
+      jobs: ${{ steps.jobs.outputs.jobs }}
+    steps:
+    - name: Generate list of jobs
+      shell: python
+      id: jobs
+      run: |
+        jobs = [
+          { 'icon': '⬛', 'sys': 'mingw32' },
+          { 'icon': '🟦', 'sys': 'mingw64' },
+          { 'icon': '🟨', 'sys': 'ucrt64'  }, # Experimental!
+          { 'icon': '🟧', 'sys': 'clang64' }, # Experimental!
+        ]
+        print(f"::set-output name=jobs::{jobs!s}")
+
+
   win-makepkg:
     runs-on: windows-latest
+    needs: win-jobs
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { icon: '⬛', sys: mingw32 }
-          - { icon: '🟦', sys: mingw64 }
-          - { icon: '🟨', sys: ucrt64  } # Experimental!
-          - { icon: '🟧', sys: clang64 } # Experimental!
+        include: ${{ fromJson(needs.win-jobs.outputs.jobs) }}
     name: '🚧${{ matrix.icon }} ${{ matrix.sys }} | makepkg'
     defaults:
       run:
@@ -182,16 +198,14 @@ jobs:
 
 
   win-test:
-    needs: win-makepkg
+    needs:
+      - win-jobs
+      - win-makepkg
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - { icon: '⬛', sys: mingw32 }
-          - { icon: '🟦', sys: mingw64 }
-          - { icon: '🟨', sys: ucrt64  } # Experimental!
-          - { icon: '🟧', sys: clang64 } # Experimental!
+        include: ${{ fromJson(needs.win-jobs.outputs.jobs) }}
     name: '🚦${{ matrix.icon }} ${{ matrix.sys }} | test'
     defaults:
       run:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -130,10 +130,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { icon: '⬛', sys: mingw32, env: i686 }
-          - { icon: '🟦', sys: mingw64, env: x86_64 }
-          - { icon: '🟨', sys: ucrt64,  env: ucrt-x86_64 }  # Experimental!
-          - { icon: '🟧', sys: clang64, env: clang-x86_64 } # Experimental!
+          - { icon: '⬛', sys: mingw32 }
+          - { icon: '🟦', sys: mingw64 }
+          - { icon: '🟨', sys: ucrt64  } # Experimental!
+          - { icon: '🟧', sys: clang64 } # Experimental!
     name: '🚧${{ matrix.icon }} ${{ matrix.sys }} | makepkg'
     defaults:
       run:
@@ -160,7 +160,7 @@ jobs:
           git
           base-devel
           tree
-          mingw-w64-${{ matrix.env }}-toolchain
+        pacboy: toolchain:p
 
     - name: '🚧 Build package'
       run: |
@@ -171,7 +171,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.sys }}-openFPGALoader
-        path: scripts/msys2/*${{ matrix.env }}*.zst
+        path: scripts/msys2/*.zst
 
     - name: '🔍 Show package content'
       run: |
@@ -188,10 +188,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { icon: '⬛', sys: mingw32, env: i686 }
-          - { icon: '🟦', sys: mingw64, env: x86_64 }
-          - { icon: '🟨', sys: ucrt64,  env: ucrt-x86_64 }  # Experimental!
-          - { icon: '🟧', sys: clang64, env: clang-x86_64 } # Experimental!
+          - { icon: '⬛', sys: mingw32 }
+          - { icon: '🟦', sys: mingw64 }
+          - { icon: '🟨', sys: ucrt64  } # Experimental!
+          - { icon: '🟧', sys: clang64 } # Experimental!
     name: '🚦${{ matrix.icon }} ${{ matrix.sys }} | test'
     defaults:
       run:


### PR DESCRIPTION
Close #140 

This PR is based on #140. Instead of declaring the list of MSYS2 jobs twice, it is declared once, and used in the matrices of jobs win-makepkg and make-test.