### PR TITLE
ci/Release: replace openFPGALoader-Documentation subdir with a tarball

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -259,4 +259,4 @@ jobs:
       with:
         token: ${{ github.token }}
         tag: 'nightly'
-        files: artifact/*-openFPGALoader/*
+        files: artifact/**/*

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -25,6 +25,7 @@ jobs:
     - name: '📤 Upload artifact: HTML'
       uses: actions/upload-artifact@v2
       with:
+        name: openFPGALoader-Documentation
         path: doc/_build/html
 
 

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -22,6 +22,10 @@ jobs:
         token: ${{ github.token }}
         skip-deploy: ${{ github.event_name == 'pull_request' }}
 
+    - name: '🧹 Clean HTML build'
+      if: ${{ github.event_name != 'pull_request' }}
+      run: sudo rm -rf doc/_build/html/.git
+
     - name: '📤 Upload artifact: HTML'
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -243,9 +243,15 @@ jobs:
       with:
         path: artifact
 
+    - name: '✉️ Package Documentation'
+      run: |
+        cd artifact
+        tar cvzf openFPGALoader-Documentation.tar.gz openFPGALoader-Documentation
+        rm -rf openFPGALoader-Documentation
+
     # Tagged: create a pre-release or a release (semver)
     # Untagged: update the assets of pre-release 'nightly'
-    - uses: eine/tip@master
+    - uses: '📦 eine/tip@master'
       with:
         token: ${{ github.token }}
         tag: 'nightly'


### PR DESCRIPTION
When the Sphinx documentation was added, I overlooked that the whole site was being uploaded to the "nightly" release, uncompressed! I'm sorry about that 😭 

This PR fixes that issue. The documentation artifact is named, and it is compressed in a tarball, so that the release action can push it without file explosion.