### PR TITLE
part: add support for Anlogic ELF2 EF2M45

### DIFF
--- a/doc/compatibility/fpga.rst
+++ b/doc/compatibility/fpga.rst
@@ -7,6 +7,7 @@ FPGAs
  Vendor  Model                                                                                                                               Memory Flash
 ======== =================================================================================================================================== ====== =====
 Anlogic  `EG4S20 <http://www.anlogic.com/prod_view.aspx?TypeId=10&Id=168&FId=t3:10:3>`__                                                     OK     AS
+Anlogic  `EF2M45 <http://www.anlogic.com/prod_view.aspx?TypeId=12&Id=170&FId=t3:12:3>`__                                                     OK     AS
  Efinix  `Trion T8 <https://www.efinixinc.com/products-trion.html>`__                                                                        NA     OK
   Gowin  `GW1N (GW1N-1, GW1N-4, GW1NR-9, GW1NS-2C, GW1NSR-4C) <https://www.gowinsemi.com/en/product/detail/2/>`__                            OK     IF
   Intel  Cyclone III `EP3C16 <https://www.intel.com/content/www/us/en/programmable/products/fpga/cyclone-series/cyclone-iii/support.html>`__ OK     OK

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -19,6 +19,7 @@ typedef struct {
 /* Highest nibble (version) must always be set to 0 */
 static std::map <int, fpga_model> fpga_list = {
 	{0x0a014c35, {"anlogic", "eagle s20", "EG4S20BG256", 8}},
+	{0x00004c37, {"anlogic", "elf2", "EF2M45", 8}},
 
 	{0x0362D093, {"xilinx", "artix a7 35t", "xc7a35", 6}},
 	{0x0362c093, {"xilinx", "artix a7 50t",  "xc7a50t", 6}},


### PR DESCRIPTION
Anlogic EF2M45 is a FPGA with a co-packaged 4Mbit SPI Flash, and the
JTAG interface is the same with EG4S20.

Add support for it by adding it to the part database.

SPI Flash programming and SRAM programming are both tested.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>