### PR TITLE
efinix: add support for Titanium Ti60 f225 dev kit

### DIFF
--- a/doc/compatibility/board.rst
+++ b/doc/compatibility/board.rst
@@ -63,6 +63,7 @@ Boards
                    xtrx `FairWaves XTRXPro <https://www.crowdsupply.com/fairwaves/xtrx>`__                                                                                Artix xc7a50tcpg236           OK        OK
              xyloni_spi `Efinix Xyloni <https://www.efinixinc.com/products-devkits-xyloni.html>`__                                                                        Trion T8F81                   NA        AS
   trion_t120_bga576_spi `Efinix Trion T120 BGA576 Dev Kit <https://www.efinixinc.com/products-devkits-triont120bga576.html>`__                                            Trion T120BGA576              NA        AS
+    trion_ti60_f225_spi `Efinix Titanium F225 Dev Kit <https://www.efinixinc.com/products-devkits-titaniumti60f225.html>`__                                               Titanium Ti60F225             NA        AS
                    xmf3 `PLDkit XMF3 <https://pldkit.com/xilinx/xmf3>`__                                                                                                  Xilinx xc3s200ft256, xcf01s   OK        OK
                zedboard `Avnet ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`__                                     zynq7000 xc7z020clg484        OK        NA
 ======================= ================================================================================================================================================= ============================= ========= ========

--- a/doc/compatibility/fpga.rst
+++ b/doc/compatibility/fpga.rst
@@ -10,6 +10,7 @@ FPGAs
      Anlogic  `EF2M45 <http://www.anlogic.com/prod_view.aspx?TypeId=12&Id=170&FId=t3:12:3>`__                                                     OK     OK
 Cologne Chip  `GateMate Series <https://colognechip.com/programmable-logic/gatemate/>`__                                                          OK     OK
       Efinix  `Trion T8 <https://www.efinixinc.com/products-trion.html>`__                                                                        NA     OK
+      Efinix  `Titanium Ti60 <https://www.efinixinc.com/products-titanium.html>`__                                                                NA     OK
        Gowin  `GW1N (GW1N-1, GW1N-4, GW1NR-9, GW1NS-2C, GW1NSR-4C) <https://www.gowinsemi.com/en/product/detail/2/>`__                            OK     IF
        Intel  Cyclone III `EP3C16 <https://www.intel.com/content/www/us/en/programmable/products/fpga/cyclone-series/cyclone-iii/support.html>`__ OK     OK
        Intel  Cyclone IV CE `EP4CE22 <https://www.intel.com/content/www/us/en/products/programmable/fpga/cyclone-iv/features.html>`__             OK     OK

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -159,6 +159,9 @@ static std::map <std::string, target_board_t> board_list = {
 	SPI_BOARD("trion_t120_bga576","efinix", "efinix_spi_ft2232",
 			DBUS4, DBUS5, DBUS7, DBUS3, DBUS0, DBUS1, DBUS2, DBUS6, 0, CABLE_DEFAULT),
 	JTAG_BOARD("trion_t120_bga576_jtag", "",        "ft2232_b",     0, 0, CABLE_DEFAULT),
+	SPI_BOARD("titanium_ti60_f225","efinix", "efinix_spi_ft4232",
+			DBUS4, DBUS5, DBUS7, DBUS3, DBUS0, DBUS1, DBUS2, DBUS6, 0, CABLE_DEFAULT),
+	JTAG_BOARD("titanium_ti60_f225_jtag", "","efinix_jtag_ft4232",  0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("zedboard",        "xc7z020-clg484", "digilent_hs2", 0, 0, CABLE_DEFAULT),
 };
 

--- a/src/efinix.cpp
+++ b/src/efinix.cpp
@@ -53,6 +53,8 @@ Efinix::Efinix(Jtag* jtag, const std::string &filename,
 		spi_board_name = "xyloni_spi";
 	} else if (board_name == "trion_t120_bga576_jtag") {
 		spi_board_name = "trion_t120_bga576";
+	} else if (board_name == "titanium_ti60_f225_jtag") {
+		spi_board_name = "titanium_ti60_f225";
 	} else {
 		throw std::runtime_error("Error: unknown board name");
 	}

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -61,10 +61,13 @@ static std::map <int, fpga_model> fpga_list = {
 	{0x02d020dd, {"altera", "cyclone V Soc", "5CSEBA6", 10}},
 	{0x02d010dd, {"altera", "cyclone V Soc", "5CSEMA4", 10}},
 
-	{0x00000001, {"efinix", "Trion", "T4/T8",            4}},
-	{0x00210a79, {"efinix", "Trion", "T8QFP144/T13/T20", 4}},
-	{0x00220a79, {"efinix", "Trion", "T55/T85/T120",     4}},
-	{0x00240a79, {"efinix", "Trion", "T20BGA324/T35",    4}},
+	{0x00000001, {"efinix", "Trion",    "T4/T8",            4}},
+	{0x00210a79, {"efinix", "Trion",    "T8QFP144/T13/T20", 4}},
+	{0x00220a79, {"efinix", "Trion",    "T55/T85/T120",     4}},
+	{0x00240a79, {"efinix", "Trion",    "T20BGA324/T35",    4}},
+	{0x00660a79, {"efinix", "Titanium", "Ti60",             4}},
+	{0x00360a79, {"efinix", "Titanium", "Ti60ES",           4}},
+	{0x00661a79, {"efinix", "Titanium", "Ti35",             4}},
 
 	{0x010F0043, {"lattice", "CrosslinkNX", "LIFCL-17", 8}},
 	{0x010F1043, {"lattice", "CrosslinkNX", "LIFCL-40", 8}},


### PR DESCRIPTION
This is the support for Ti60 dev kit.
Please have a look before merging it.
This is the FTDI part of the dev board:
![image](https://user-images.githubusercontent.com/1468818/145890024-b32037e9-7452-42d7-b351-676b3617be2e.png)
It works on my board:
![image](https://user-images.githubusercontent.com/1468818/145890132-fd2755ba-a867-417d-b3e3-0dbc0ff5bb5f.png)
