### PR TITLE
ci: fix step 'Show package content'

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -196,7 +196,8 @@ jobs:
       run: |
         mkdir tmp
         cd tmp
-        tar -xf ../scripts/msys2/*.zst
+        zstd -d ../scripts/msys2/*.zst
+        tar -xf ../scripts/msys2/*.tar
         tree .
 
 


### PR DESCRIPTION
It seems that some change in `tar` is producing issues when trying to extract `.zst` files in the CI workflow. This PR uses `zstd` explicitly, in order to work around it.

I reported the issue to MSYS2 maintainers, and they are having a look at the problem. Hence, this fix might not be needed in a few days. @trabucayre, it's up to you to merge this PR, or to just wait for it to be fixed upstream. The main motivation for this PR is making you aware.