### PR TITLE
ci: use reusable composite action and reusable workflow from msys2/setup-msys2

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -131,114 +131,34 @@ jobs:
     name: ⬜ Generate list of MSYS2 jobs
     runs-on: ubuntu-latest
     outputs:
-      jobs: ${{ steps.jobs.outputs.jobs }}
+      jobs: ${{ steps.matrix.outputs.jobs }}
     steps:
-    - name: Generate list of jobs
-      shell: python
-      id: jobs
-      run: |
-        jobs = [
-          { 'icon': '⬛', 'sys': 'mingw32' },
-          { 'icon': '🟦', 'sys': 'mingw64' },
-          { 'icon': '🟨', 'sys': 'ucrt64'  }, # Experimental!
-          { 'icon': '🟧', 'sys': 'clang64' }, # Experimental!
-        ]
-        print(f"::set-output name=jobs::{jobs!s}")
+    - id: matrix
+      uses: msys2/setup-msys2/matrix@main
+      with:
+        systems: >-
+          mingw32
+          mingw64
+          ucrt64
+          clang64
 
-
-  win-makepkg:
-    runs-on: windows-latest
+  win:
     needs: win-jobs
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.win-jobs.outputs.jobs) }}
-    name: '🚧${{ matrix.icon }} ${{ matrix.sys }} | makepkg'
-    defaults:
-      run:
-        shell: msys2 {0}
-    env:
-      MINGW_ARCH: ${{ matrix.sys }}
-    steps:
-
-    - name: '⚙️ git config'
-      run: git config --global core.autocrlf input
-      shell: bash
-
-    - name: '🧰 Checkout'
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - name: '${{ matrix.icon }} Setup MSYS2'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: ${{ matrix.sys }}
-        update: true
-        install: >
-          git
-          base-devel
-          tree
-        pacboy: toolchain:p
-
-    - name: '🚧 Build package'
-      run: |
-        cd scripts/msys2
-        makepkg-mingw --noconfirm --noprogressbar -sCLf
-
-    - name: '📤 Upload artifact: package'
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ matrix.sys }}-openFPGALoader
-        path: scripts/msys2/*.zst
-
-    - name: '🔍 Show package content'
-      run: |
-        mkdir tmp
-        cd tmp
-        zstd -d ../scripts/msys2/*.zst
-        tar -xf ../scripts/msys2/*.tar
-        tree .
-
-
-  win-test:
-    needs:
-      - win-jobs
-      - win-makepkg
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.win-jobs.outputs.jobs) }}
-    name: '🚦${{ matrix.icon }} ${{ matrix.sys }} | test'
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-
-    - name: '${{ matrix.icon }} Setup MSYS2'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: ${{ matrix.sys }}
-        update: true
-
-    - name: '📥 Download artifact: package'
-      uses: actions/download-artifact@v2
-      with:
-        name: ${{ matrix.sys }}-openFPGALoader
-
-    - name: '🛠️ Install package'
-      run: pacman -U --noconfirm --noprogressbar *.zst
-
-    - name: '🚦 Test package'
-      run: |
+    uses: msys2/setup-msys2/.github/workflows/PKGBUILD.yml@main
+    with:
+      name: openFPGALoader
+      matrix: ${{ needs.win-jobs.outputs.jobs }}
+      path: scripts/msys2
+      test: |
+        uname -a
+        which openFPGALoader
         openFPGALoader --help
         openFPGALoader --detect || true
 
 
   Release:
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
-    needs: [ lin-test, win-test ]
+    needs: [ lin-test, win ]
     runs-on: ubuntu-latest
     name: '📦 Release'
     steps:


### PR DESCRIPTION
I contributed a composite action and a reusable workflow to msys2/setup-msys2, in order to reduce the duplication in all the repos building and testing MSYS2 packages. This PR replaces the `win` jobs in the CI workflow in order to use those. The functionality is the same.

Find references about the differences of Action and Workflow kinds in https://github.com/pyTooling/Actions/#context.