### PR TITLE
doc: declare board compatibility through a YAML file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,7 @@ openFPGALoader
 build/
 
 # Documentation
-/doc/_build
-/doc/_theme
+/doc/__pycache__/
+/doc/_build/
+/doc/_theme/
+/doc/compatibility/boards.inc

--- a/doc/boards.py
+++ b/doc/boards.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from dataclasses import dataclass
+from yaml import load as yaml_load, Loader as yaml_loader, dump as yaml_dump
+from tabulate import tabulate
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+@dataclass
+class Board:
+    ID: str
+    Description: str = None
+    URL: str = None
+    FPGA: str = None
+    Memory: str = None
+    Flash: str = None
+
+
+def ReadDataFromYAML():
+    with (ROOT / 'boards.yml').open('r', encoding='utf-8') as fptr:
+        data = [Board(**item) for item in yaml_load(fptr, yaml_loader)]
+    return data
+
+
+def DataToTable(data, tablefmt: str = "rst"):
+    return tabulate(
+        [
+            [
+                item.ID,
+                f"`{item.Description} <{item.URL}>`__",
+                item.FPGA,
+                item.Memory,
+                item.Flash
+            ] for item in data
+        ],
+        headers=["Board name", "Description", "FPGA", "Memory", "Flash"],
+        tablefmt=tablefmt
+    )

--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -1,0 +1,402 @@
+- ID: acornCle215
+  Description: Acorn CLE 215+
+  URL: http://squirrelsresearch.com/acorn-cle-215
+  FPGA: Artix xc7a200tsbg484
+  Memory: OK
+  Flash: OK
+
+- ID: alchitry_au
+  Description: Alchitry Au
+  URL: https://alchitry.com/products/alchitry-au-fpga-development-board
+  FPGA: Artix xc7a35tftg256
+  Memory: OK
+  Flash: OK
+
+- ID: arty_a7_35t
+  Description: Digilent Arty A7
+  URL: https://reference.digilentinc.com/reference/programmable-logic/arty-a7/start
+  FPGA: Artix xc7a35ticsg324
+  Memory: OK
+  Flash: OK
+
+- ID: arty_a7_100t
+  Description: Digilent Arty A7
+  URL: https://reference.digilentinc.com/reference/programmable-logic/arty-a7/start
+  FPGA: Artix xc7a100tcsg324
+  Memory: OK
+  Flash: OK
+
+- ID: arty_s7_25
+  Description: Digilent Arty S7
+  URL: https://reference.digilentinc.com/reference/programmable-logic/arty-s7/start
+  FPGA: Spartan7 xc7s25csga324
+  Memory: OK
+  Flash: OK
+
+- ID: arty_s7_50
+  Description: Digilent Arty S7
+  URL: https://reference.digilentinc.com/reference/programmable-logic/arty-s7/start
+  FPGA: Spartan7 xc7s50csga324
+  Memory: OK
+  Flash: OK
+
+- ID: arty_z7_10
+  Description: Digilent Arty S7
+  URL: https://reference.digilentinc.com/reference/programmable-logic/arty-z7/start
+  FPGA: Zynq7000 xc7z010csg400
+  Memory: OK
+  Flash: NA
+
+- ID: arty_z7_20
+  Description: Digilent Arty S7
+  URL: https://reference.digilentinc.com/reference/programmable-logic/arty-z7/start
+  FPGA: Zynq7000 xc7z020csg400
+  Memory: OK
+  Flash: NA
+
+- ID: arty
+  Description: Digilent Analog Discovery 2
+  URL: https://reference.digilentinc.com/test-and-measurement/analog-discovery-2/start
+  FPGA: Spartan6 xc6slx25
+  Memory: OK
+  Flash: NT
+
+- ID: arty
+  Description: Digilent Digital Discovery
+  URL: https://reference.digilentinc.com/test-and-measurement/digital-discovery/start
+  FPGA: Spartan6 xc6slx25
+  Memory: OK
+  Flash: NT
+
+- ID: basys3
+  Description: Digilent Basys3
+  URL: https://reference.digilentinc.com/reference/programmable-logic/basys-3/start
+  FPGA: Artix xc7a35tcpg236
+  Memory: OK
+  Flash: OK
+
+- ID: gatemate_evb_jtag
+  Description: Cologne Chip GateMate FPGA Evaluation Board (JTAG mode)
+  URL: https://colognechip.com/programmable-logic/gatemate/
+  FPGA: Cologne Chip GateMate Series
+  Memory: OK
+  Flash: OK
+
+- ID: gatemate_evb_spi
+  Description: Cologne Chip GateMate FPGA Evaluation Board (SPI mode)
+  URL: https://colognechip.com/programmable-logic/gatemate/
+  FPGA: Cologne Chip GateMate Series
+  Memory: OK
+  Flash: OK
+
+- ID: gatemate_pgm_spi
+  Description: Cologne Chip GateMate FPGA Programmer (SPI mode)
+  URL: https://colognechip.com/programmable-logic/gatemate/
+  FPGA: Cologne Chip GateMate Series
+  Memory: OK
+  Flash: OK
+
+- ID: colorlight
+  Description: Colorlight 5A-75B (version 7)
+  URL: https://fr.aliexpress.com/item/32281130824.html
+  FPGA: ECP5 LFE5U-25F-6BG256C
+  Memory: OK
+  Flash: OK
+
+- ID: colorlight_i5
+  Description: Colorlight I5
+  URL: https://www.colorlight-led.com/product/colorlight-i5-led-display-receiver-card.html
+  FPGA: ECP5 LFE5U-25F-6BG381C
+  Memory: OK
+  Flash: OK
+
+- ID: crosslinknx_evn
+  Description: Lattice CrossLink-NX Evaluation Board
+  URL: https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/CrossLink-NXEvaluationBoard
+  FPGA: Nexus LIFCL-40
+  Memory: OK
+  Flash: OK
+
+- ID: cyc1000
+  Description: Trenz cyc1000
+  URL: https://shop.trenz-electronic.de/en/TEI0003-02-CYC1000-with-Cyclone-10-FPGA-8-MByte-SDRAM
+  FPGA: Cyclone 10 LP 10CL025YU256C8G
+  Memory: OK
+  Flash: OK
+
+- ID: de0
+  Description: Terasic DE0
+  URL: https://www.terasic.com.tw/cgi-bin/page/archive.pl?No=364
+  FPGA: Cyclone III EP3C16F484C6
+  Memory: OK
+  Flash: NT
+
+- ID: de0nano
+  Description: Terasic de0nano
+  URL: https://www.terasic.com.tw/cgi-bin/page/archive.pl?No=593
+  FPGA: Cyclone IV E EP4CE22F17C6
+  Memory: OK
+  Flash: OK
+
+- ID: de0nanoSoc
+  Description: Terasic de0nanoSoc
+  URL: https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=205&No=941
+  FPGA: Cyclone V SoC 5CSEMA4U23C6
+  Memory: OK
+
+- ID: de10nano
+  Description: Terasic de10Nano
+  URL: https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=205&No=1046
+  FPGA: Cyclone V SoC 5CSEBA6U23I7
+  Memory: OK
+
+- ID: ecp5_evn
+  Description: Lattice ECP5 5G Evaluation Board
+  URL: https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/ECP5EvaluationBoard
+  FPGA: ECP5G LFE5UM5G-85F
+  Memory: OK
+  Flash: OK
+
+- ID: ecpix5
+  Description: LambdaConcept ECPIX-5
+  URL: https://shop.lambdaconcept.com/home/46-2-ecpix-5.html#/2-ecpix_5_fpga-ecpix_5_85f
+  FPGA: ECP5 LFE5UM5G-85F
+  Memory: OK
+  Flash: OK
+
+- ID: fireant
+  Description: Fireant Trion T8
+  URL: https://www.crowdsupply.com/jungle-elec/fireant
+  FPGA: Trion T8F81
+  Memory: NA
+  Flash: AS
+
+- ID: fomu
+  Description: Fomu PVT
+  URL: https://tomu.im/fomu.html
+  FPGA: iCE40UltraPlus UP5K
+  Memory: NA
+  Flash: OK
+
+- ID: honeycomb
+  Description: honeycomb
+  URL: https://github.com/Disasm/honeycomb-pcb
+  FPGA: littleBee GW1NS-2C
+  Memory: OK
+  Flash: IF
+
+- ID: ice40_generic
+  Description: iCEBreaker
+  URL: https://1bitsquared.com/collections/fpga/products/icebreaker
+  FPGA: iCE40UltraPlus UP5K
+  Memory: NA
+  Flash: AS
+
+- ID: icebreaker-bitsy
+  Description: iCEBreaker-bitsy
+  URL: https://1bitsquared.com/collections/fpga/products/icebreaker-bitsy
+  FPGA: iCE40UltraPlus UP5K
+  Memory: NA
+  Flash: OK
+
+- ID: ice40_generic
+  Description: icestick
+  URL: https://www.latticesemi.com/icestick
+  FPGA: iCE40 HX1k
+  Memory: NA
+  Flash: AS
+
+- ID: ice40_generic
+  Description: iCE40-HX8K
+  URL: https://www.latticesemi.com/Products/DevelopmentBoardsAndKits/iCE40HX8KBreakoutBoard.aspx
+  FPGA: iCE40 HX8k
+  Memory: NT
+  Flash: AS
+
+- ID: ice40_generic
+  Description: Olimex iCE40HX1K-EVB
+  URL: https://www.olimex.com/Products/FPGA/iCE40/iCE40HX1K-EVB/open-source-hardware
+  FPGA: iCE40 HX1k
+  Memory: NT
+  Flash: AS
+
+- ID: ice40_generic
+  Description: Olimex iCE40HX8K-EVB
+  URL: https://www.olimex.com/Products/FPGA/iCE40/iCE40HX8K-EVB/open-source-hardware
+  FPGA: iCE40 HX8k
+  Memory: NT
+  Flash: AS
+
+- ID: ice40_generic
+  Description: Icezum Alhambra II
+  URL: https://alhambrabits.com/alhambra
+  FPGA: iCE40 HX4k
+  Memory: NT
+  Flash: AS
+
+- ID: kc705
+  Description: Xilinx KC705
+  URL: https://www.xilinx.com/products/boards-and-kits/ek-k7-kc705-g.html
+  FPGA: Kintex7 xc7k325t
+  Memory: OK
+  Flash: NT
+
+- ID: licheeTang
+  Description: Sipeed Lichee Tang
+  URL: https://tang.sipeed.com/en/hardware-overview/lichee-tang/
+  FPGA: eagle s20 EG4S20BG256
+  Memory: OK
+  Flash: OK
+
+- ID: machXO2EVN
+  Description: Lattice MachXO2 Breakout Board Evaluation Kit
+  URL: https://www.latticesemi.com/products/developmentboardsandkits/machxo2breakoutboard
+  FPGA: MachXO2 LCMXO2-7000HE
+  Memory: OK
+  Flash: OK
+
+- ID: machXO3EVN
+  Description: Lattice MachXO3D Development Board
+  URL: https://www.latticesemi.com/products/developmentboardsandkits/machxo3d_development_board
+  FPGA: MachXO3D LCMXO3D-9400HC
+  Memory: OK
+  Flash: NT
+
+- ID: machXO3SK
+  Description: Lattice MachXO3LF Starter Kit
+  URL: https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/MachXO3LFStarterKit
+  FPGA: MachXO3 LCMX03LF-6900C
+  Memory: OK
+  Flash: OK
+
+- ID: nexysVideo
+  Description: Digilent Nexys Video
+  URL: https://reference.digilentinc.com/reference/programmable-logic/nexys-video/start
+  FPGA: Artix xc7a200tsbg484
+  Memory: OK
+  Flash: OK
+
+- ID: orangeCrab
+  Description: Orange Crab
+  URL: https://github.com/gregdavill/OrangeCrab
+  FPGA: ECP5 LFE5U-25F-8MG285C
+  Memory: OK (JTAG)
+  Flash: OK (DFU)
+
+- ID: pipistrello
+  Description: Saanlima Pipistrello LX45
+  URL: http://pipistrello.saanlima.com/index.php?title=Welcome_to_Pipistrello
+  FPGA: Spartan6 xc6slx45-csg324
+  Memory: OK
+  Flash: OK
+
+- ID: qmtechCycloneIV
+  Description: QMTech CycloneIV Core Board
+  URL: https://fr.aliexpress.com/item/32949281189.html
+  FPGA: Cyclone IV EP4CE15F23C8N
+  Memory: OK
+  Flash: OK
+
+- ID: qmtechCycloneV
+  Description: QMTech CycloneV Core Board
+  URL: https://fr.aliexpress.com/i/1000006622149.html
+  FPGA: Cyclone V 5CEFA2F23I7
+  Memory: OK
+  Flash: OK
+
+- ID: runber
+  Description: SeeedStudio Gowin RUNBER
+  URL: https://www.seeedstudio.com/Gowin-RUNBER-Development-Board-p-4779.html
+  FPGA: littleBee GW1N-4
+  Memory: OK
+  Flash: IF/EF
+
+- ID: runber
+  Description: Scarab Hardware MiniSpartan6+
+  URL: https://www.kickstarter.com/projects/1812459948/minispartan6-a-powerful-fpga-board-and-easy-to-use
+  FPGA: Spartan6 xc6slx25-3-ftg256
+  Memory: OK
+  Flash: NT
+
+- ID: spartanEdgeAccelBoard
+  Description: SeeedStudio Spartan Edge Accelerator Board
+  URL: http://wiki.seeedstudio.com/Spartan-Edge-Accelerator-Board
+  FPGA: Spartan7 xc7s15ftgb196
+  Memory: OK
+  Flash: NA
+
+- ID: tangnano
+  Description: Sipeed Tang Nano
+  URL: https://tangnano.sipeed.com/en/
+  FPGA: littleBee GW1N-1
+  Memory: OK
+
+- ID: tangnano4k
+  Description: Sipeed Tang Nano 4K
+  URL: https://tangnano.sipeed.com/en/
+  FPGA: littleBee GW1NSR-4C
+  Memory: OK
+  Flash: IF/EF
+
+- ID: tec0117
+  Description: Trenz Gowin LittleBee (TEC0117)
+  URL: https://shop.trenz-electronic.de/en/TEC0117-01-FPGA-Module-with-GOWIN-LittleBee-and-8-MByte-internal-SDRAM
+  FPGA: littleBee GW1NR-9
+  Memory: OK
+  Flash: IF
+
+- ID: ulx3s
+  Description: Radiona ULX3S
+  URL: https://radiona.org/ulx3s/
+  FPGA: ECP5 LFE5U
+  Memory: OK
+  Flash: OK
+
+- ID: ulx3s_dfu
+  Description: Radiona ULX3S DFU mode
+  URL: https://github.com/emard/had2019-playground
+  FPGA: ECP5 LFE5U
+  Memory: NA
+  Flash: OK
+
+- ID: xtrx
+  Description: FairWaves XTRXPro
+  URL: https://www.crowdsupply.com/fairwaves/xtrx
+  FPGA: Artix xc7a50tcpg236
+  Memory: OK
+  Flash: OK
+
+- ID: xyloni_spi
+  Description: Efinix Xyloni
+  URL: https://www.efinixinc.com/products-devkits-xyloni.html
+  FPGA: Trion T8F81
+  Memory: NA
+  Flash: AS
+
+- ID: trion_t120_bga576_spi
+  Description: Efinix Trion T120 BGA576 Dev Kit
+  URL: https://www.efinixinc.com/products-devkits-triont120bga576.html
+  FPGA: Trion T120BGA576
+  Memory: NA
+  Flash: AS
+
+- ID: trion_ti60_f225_spi
+  Description: Efinix Titanium F225 Dev Kit
+  URL: https://www.efinixinc.com/products-devkits-titaniumti60f225.html
+  FPGA: Titanium Ti60F225
+  Memory: NA
+  Flash: AS
+
+- ID: xmf3
+  Description: PLDkit XMF3
+  URL: https://pldkit.com/xilinx/xmf3
+  FPGA: Xilinx xc3s200ft256, xcf01s
+  Memory: OK
+  Flash: OK
+
+- ID: zedboard
+  Description: Avnet ZedBoard
+  URL: https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/
+  FPGA: zynq7000 xc7z020clg484
+  Memory: OK
+  Flash: NA

--- a/doc/compatibility/board.rst
+++ b/doc/compatibility/board.rst
@@ -11,68 +11,7 @@ Boards
     openFPGALoader -b arty bitstream.bit # Loading in SRAM (volatile)
     openFPGALoader -b arty -f bitstream.bit # Writing in flash (non-volatile)
 
-======================= ================================================================================================================================================= ============================= ========= ========
-             Board name Description                                                                                                                                       FPGA                          Memory    Flash
-======================= ================================================================================================================================================= ============================= ========= ========
-            acornCle215 `Acorn CLE 215+ <http://squirrelsresearch.com/acorn-cle-215/>`__                                                                                  Artix xc7a200tsbg484          OK        OK
-            alchitry_au `Alchitry Au <https://alchitry.com/products/alchitry-au-fpga-development-board>`__                                                                Artix xc7a35tftg256           OK        OK
-            arty_a7_35t `Digilent Arty A7 <https://reference.digilentinc.com/reference/programmable-logic/arty-a7/start>`__                                               Artix xc7a35ticsg324          OK        OK
-           arty_a7_100t `Digilent Arty A7 <https://reference.digilentinc.com/reference/programmable-logic/arty-a7/start>`__                                               Artix xc7a100tcsg324          OK        OK
-             arty_s7_25 `Digilent Arty S7 <https://reference.digilentinc.com/reference/programmable-logic/arty-s7/start>`__                                               Spartan7 xc7s25csga324        OK        OK
-             arty_s7_50 `Digilent Arty S7 <https://reference.digilentinc.com/reference/programmable-logic/arty-s7/start>`__                                               Spartan7 xc7s50csga324        OK        OK
-             arty_z7_10 `Digilent Arty S7 <https://reference.digilentinc.com/reference/programmable-logic/arty-z7/start>`__                                               Zynq7000 xc7z010csg400        OK        NA
-             arty_z7_20 `Digilent Arty S7 <https://reference.digilentinc.com/reference/programmable-logic/arty-z7/start>`__                                               Zynq7000 xc7z020csg400        OK        NA
-                   arty `Digilent Analog Discovery 2 <https://reference.digilentinc.com/test-and-measurement/analog-discovery-2/start>`__                                 Spartan6 xc6slx25             OK        NT
-                   arty `Digilent Digital Discovery <https://reference.digilentinc.com/test-and-measurement/digital-discovery/start>`__                                   Spartan6 xc6slx25             OK        NT
-                 basys3 `Digilent Basys3 <https://reference.digilentinc.com/reference/programmable-logic/basys-3/start>`__                                                Artix xc7a35tcpg236           OK        OK
-      gatemate_evb_jtag `Cologne Chip GateMate FPGA Evaluation Board (JTAG mode) <https://colognechip.com/programmable-logic/gatemate/>`__                                Cologne Chip GateMate Series  OK        OK
-       gatemate_evb_spi `Cologne Chip GateMate FPGA Evaluation Board (SPI mode) <https://colognechip.com/programmable-logic/gatemate/>`__                                 Cologne Chip GateMate Series  OK        OK
-       gatemate_pgm_spi `Cologne Chip GateMate FPGA Programmer (SPI mode) <https://colognechip.com/programmable-logic/gatemate/>`__                                       Cologne Chip GateMate Series  OK        OK
-             colorlight `Colorlight 5A-75B (version 7) <https://fr.aliexpress.com/item/32281130824.html>`__                                                               ECP5 LFE5U-25F-6BG256C        OK        OK
-          colorlight_i5 `Colorlight I5 <https://www.colorlight-led.com/product/colorlight-i5-led-display-receiver-card.html>`__                                           ECP5 LFE5U-25F-6BG381C        OK        OK
-        crosslinknx_evn `Lattice CrossLink-NX Evaluation Board <https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/CrossLink-NXEvaluationBoard>`__          Nexus LIFCL-40                OK        OK
-                cyc1000 `Trenz cyc1000 <https://shop.trenz-electronic.de/en/TEI0003-02-CYC1000-with-Cyclone-10-FPGA-8-MByte-SDRAM>`__                                     Cyclone 10 LP 10CL025YU256C8G OK        OK
-                    de0 `Terasic DE0 <https://www.terasic.com.tw/cgi-bin/page/archive.pl?No=364>`__                                                                       Cyclone III EP3C16F484C6      OK        NT
-                de0nano `Terasic de0nano <https://www.terasic.com.tw/cgi-bin/page/archive.pl?No=593>`__                                                                   Cyclone IV E EP4CE22F17C6     OK        OK
-             de0nanoSoc `Terasic de0nanoSoc <https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=205&No=941>`__                                Cyclone V SoC 5CSEMA4U23C6    OK
-               de10nano `Terasic de10Nano <https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=205&No=1046>`__                                 Cyclone V SoC 5CSEBA6U23I7    OK
-               ecp5_evn `Lattice ECP5 5G Evaluation Board <https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/ECP5EvaluationBoard>`__                       ECP5G LFE5UM5G-85F            OK        OK
-                 ecpix5 `LambdaConcept ECPIX-5 <https://shop.lambdaconcept.com/home/46-2-ecpix-5.html#/2-ecpix_5_fpga-ecpix_5_85f>`__                                     ECP5 LFE5UM5G-85F             OK        OK
-                fireant `Fireant Trion T8 <https://www.crowdsupply.com/jungle-elec/fireant>`__                                                                            Trion T8F81                   NA        AS
-                   fomu `Fomu PVT <https://tomu.im/fomu.html>`__                                                                                                          iCE40UltraPlus UP5K           NA        OK
-              honeycomb `honeycomb <https://github.com/Disasm/honeycomb-pcb>`__                                                                                           littleBee GW1NS-2C            OK        IF
-          ice40_generic `iCEBreaker <https://1bitsquared.com/collections/fpga/products/icebreaker>`__                                                                     iCE40UltraPlus UP5K           NA        AS
-       icebreaker-bitsy `iCEBreaker-bitsy <https://1bitsquared.com/collections/fpga/products/icebreaker-bitsy>`__                                                         iCE40UltraPlus UP5K           NA        OK
-          ice40_generic `icestick <https://www.latticesemi.com/icestick>`__                                                                                               iCE40 HX1k                    NA        AS
-          ice40_generic `iCE40-HX8K <https://www.latticesemi.com/Products/DevelopmentBoardsAndKits/iCE40HX8KBreakoutBoard.aspx>`__                                        iCE40 HX8k                    NT        AS
-          ice40_generic `Olimex iCE40HX1K-EVB <https://www.olimex.com/Products/FPGA/iCE40/iCE40HX1K-EVB/open-source-hardware>`__                                          iCE40 HX1k                    NT        AS
-          ice40_generic `Olimex iCE40HX8K-EVB <https://www.olimex.com/Products/FPGA/iCE40/iCE40HX8K-EVB/open-source-hardware>`__                                          iCE40 HX8k                    NT        AS
-          ice40_generic `Icezum Alhambra II <https://alhambrabits.com/alhambra>`__                                                                                        iCE40 HX4k                    NT        AS
-                  kc705 `Xilinx KC705 <https://www.xilinx.com/products/boards-and-kits/ek-k7-kc705-g.html>`__                                                             Kintex7 xc7k325t              OK        NT
-             licheeTang `Sipeed Lichee Tang <https://tang.sipeed.com/en/hardware-overview/lichee-tang/>`__                                                                eagle s20 EG4S20BG256         OK        OK
-             machXO2EVN `Lattice MachXO2 Breakout Board Evaluation Kit  <https://www.latticesemi.com/products/developmentboardsandkits/machxo2breakoutboard>`__           MachXO2 LCMXO2-7000HE         OK        OK
-             machXO3EVN `Lattice MachXO3D Development Board  <https://www.latticesemi.com/products/developmentboardsandkits/machxo3d_development_board>`__                MachXO3D LCMXO3D-9400HC       OK        NT
-              machXO3SK `Lattice MachXO3LF Starter Kit <https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/MachXO3LFStarterKit>`__                          MachXO3 LCMX03LF-6900C        OK        OK
-             nexysVideo `Digilent Nexys Video <https://reference.digilentinc.com/reference/programmable-logic/nexys-video/start>`__                                       Artix xc7a200tsbg484          OK        OK
-             orangeCrab `Orange Crab <https://github.com/gregdavill/OrangeCrab>`__                                                                                        ECP5 LFE5U-25F-8MG285C        OK (JTAG) OK (DFU)
-            pipistrello `Saanlima Pipistrello LX45 <http://pipistrello.saanlima.com/index.php?title=Welcome_to_Pipistrello>`__                                            Spartan6 xc6slx45-csg324      OK        OK
-        qmtechCycloneIV `QMTech CycloneIV Core Board <https://fr.aliexpress.com/item/32949281189.html>`__                                                                 Cyclone IV EP4CE15F23C8N      OK        OK
-         qmtechCycloneV `QMTech CycloneV Core Board <https://fr.aliexpress.com/i/1000006622149.html>`__                                                                   Cyclone V 5CEFA2F23I7         OK        OK
-                 runber `SeeedStudio Gowin RUNBER <https://www.seeedstudio.com/Gowin-RUNBER-Development-Board-p-4779.html>`__                                             littleBee GW1N-4              OK        IF/EF
-                 runber `Scarab Hardware MiniSpartan6+ <https://www.kickstarter.com/projects/1812459948/minispartan6-a-powerful-fpga-board-and-easy-to-use>`__            Spartan6 xc6slx25-3-ftg256    OK        NT
-  spartanEdgeAccelBoard `SeeedStudio Spartan Edge Accelerator Board <http://wiki.seeedstudio.com/Spartan-Edge-Accelerator-Board>`__                                       Spartan7 xc7s15ftgb196        OK        NA
-               tangnano `Sipeed Tang Nano <https://tangnano.sipeed.com/en/>`__                                                                                            littleBee GW1N-1              OK
-             tangnano4k `Sipeed Tang Nano 4K <https://tangnano.sipeed.com/en/>`__                                                                                         littleBee GW1NSR-4C           OK        IF/EF
-                tec0117 `Trenz Gowin LittleBee (TEC0117) <https://shop.trenz-electronic.de/en/TEC0117-01-FPGA-Module-with-GOWIN-LittleBee-and-8-MByte-internal-SDRAM>`__  littleBee GW1NR-9             OK        IF
-                  ulx3s `Radiona ULX3S <https://radiona.org/ulx3s/>`__                                                                                                    ECP5 LFE5U                    OK        OK
-              ulx3s_dfu `Radiona ULX3S DFU mode <https://github.com/emard/had2019-playground>`__                                                                          ECP5 LFE5U                    NA        OK
-                   xtrx `FairWaves XTRXPro <https://www.crowdsupply.com/fairwaves/xtrx>`__                                                                                Artix xc7a50tcpg236           OK        OK
-             xyloni_spi `Efinix Xyloni <https://www.efinixinc.com/products-devkits-xyloni.html>`__                                                                        Trion T8F81                   NA        AS
-  trion_t120_bga576_spi `Efinix Trion T120 BGA576 Dev Kit <https://www.efinixinc.com/products-devkits-triont120bga576.html>`__                                            Trion T120BGA576              NA        AS
-    trion_ti60_f225_spi `Efinix Titanium F225 Dev Kit <https://www.efinixinc.com/products-devkits-titaniumti60f225.html>`__                                               Titanium Ti60F225             NA        AS
-                   xmf3 `PLDkit XMF3 <https://pldkit.com/xilinx/xmf3>`__                                                                                                  Xilinx xc3s200ft256, xcf01s   OK        OK
-               zedboard `Avnet ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`__                                     zynq7000 xc7z020clg484        OK        NA
-======================= ================================================================================================================================================= ============================= ========= ========
+.. include:: boards.inc
 
 * IF: Internal Flash
 * EF: External Flash

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -101,3 +101,30 @@ extlinks = {
     "ghpull": ("https://github.com/trabucayre/openFPGALoader/pull/%s", "pull request #"),
     "ghsrc": ("https://github.com/trabucayre/openFPGALoader/blob/master/%s", None),
 }
+
+# -- Read board data from boards.yml
+
+from dataclasses import dataclass
+from yaml import load as yaml_load, Loader as yaml_loader, dump as yaml_dump
+from tabulate import tabulate
+
+@dataclass
+class Board:
+    ID: str
+    Description: str = None
+    URL: str = None
+    FPGA: str = None
+    Memory: str = None
+    Flash: str = None
+
+with (ROOT / 'boards.yml').open('r', encoding='utf-8') as fptr:
+    data = [Board(**item) for item in yaml_load(fptr, yaml_loader)]
+
+table = tabulate(
+    [[item.ID, f"`{item.Description} <{item.URL}>`__", item.FPGA, item.Memory, item.Flash] for item in data],
+    headers=["Board name", "Description", "FPGA", "Memory", "Flash"],
+    tablefmt="rst"
+)
+
+with (ROOT / "compatibility/boards.inc").open("w", encoding="utf-8") as wptr:
+    wptr.write(table)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,9 +5,14 @@ from os.path import abspath
 from pathlib import Path
 from json import loads
 
+
 ROOT = Path(__file__).resolve().parent
 
 sys_path.insert(0, abspath("."))
+
+
+from boards import ReadDataFromYAML, DataToTable
+
 
 # -- General configuration ------------------------------------------------
 
@@ -102,29 +107,7 @@ extlinks = {
     "ghsrc": ("https://github.com/trabucayre/openFPGALoader/blob/master/%s", None),
 }
 
-# -- Read board data from boards.yml
-
-from dataclasses import dataclass
-from yaml import load as yaml_load, Loader as yaml_loader, dump as yaml_dump
-from tabulate import tabulate
-
-@dataclass
-class Board:
-    ID: str
-    Description: str = None
-    URL: str = None
-    FPGA: str = None
-    Memory: str = None
-    Flash: str = None
-
-with (ROOT / 'boards.yml').open('r', encoding='utf-8') as fptr:
-    data = [Board(**item) for item in yaml_load(fptr, yaml_loader)]
-
-table = tabulate(
-    [[item.ID, f"`{item.Description} <{item.URL}>`__", item.FPGA, item.Memory, item.Flash] for item in data],
-    headers=["Board name", "Description", "FPGA", "Memory", "Flash"],
-    tablefmt="rst"
-)
+# -- Generate partial board compatibility page (`board.inc`) with data from `boards.yml`
 
 with (ROOT / "compatibility/boards.inc").open("w", encoding="utf-8") as wptr:
-    wptr.write(table)
+    wptr.write(DataToTable(ReadDataFromYAML()))

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,3 @@
+pyyaml
 sphinx
+tabulate


### PR DESCRIPTION
Instead of manually writing the board compatibility table in the docs, this PR uses a YAML file and a Python script:

- Boards are declared in the YAML file, which provides a machine-readable solution for consumers of this repo to query the data.
- The Python script reads the YAML file and generates a restructuredtext table through [tabulate](https://pypi.org/project/tabulate/).

No content is changed, so the documentation looks exactly the same. This is an internal enhancement related to #105.