### PR TITLE
doc: add field 'Constraints' to 'boards.yml'

### DIFF
--- a/doc/boards.py
+++ b/doc/boards.py
@@ -15,6 +15,7 @@ class Board:
     FPGA: str = None
     Memory: str = None
     Flash: str = None
+    Constraints: str = None
 
 
 def ReadDataFromYAML():
@@ -24,6 +25,13 @@ def ReadDataFromYAML():
 
 
 def DataToTable(data, tablefmt: str = "rst"):
+    def processConstraints(constraints):
+        if constraints is None:
+            return None
+        if isinstance(constraints, str):
+            constraints = [constraints]
+        return " ".join([f":ref:`{item} ➚ <constraints:boards:{item.lower()}>`" for item in constraints])
+
     return tabulate(
         [
             [
@@ -31,9 +39,10 @@ def DataToTable(data, tablefmt: str = "rst"):
                 f"`{item.Description} <{item.URL}>`__",
                 item.FPGA,
                 item.Memory,
-                item.Flash
+                item.Flash,
+                processConstraints(item.Constraints)
             ] for item in data
         ],
-        headers=["Board name", "Description", "FPGA", "Memory", "Flash"],
+        headers=["Board name", "Description", "FPGA", "Memory", "Flash", "Constraints"],
         tablefmt=tablefmt
     )

--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -18,6 +18,7 @@
   FPGA: Artix xc7a35ticsg324
   Memory: OK
   Flash: OK
+  Constraints: Arty-A7-35T
 
 - ID: arty_a7_100t
   Description: Digilent Arty A7
@@ -25,6 +26,7 @@
   FPGA: Artix xc7a100tcsg324
   Memory: OK
   Flash: OK
+  Constraints: Arty-A7-100T
 
 - ID: arty_s7_25
   Description: Digilent Arty S7
@@ -32,6 +34,7 @@
   FPGA: Spartan7 xc7s25csga324
   Memory: OK
   Flash: OK
+  Constraints: Arty-S7-25
 
 - ID: arty_s7_50
   Description: Digilent Arty S7
@@ -39,6 +42,7 @@
   FPGA: Spartan7 xc7s50csga324
   Memory: OK
   Flash: OK
+  Constraints: Arty-S7-50
 
 - ID: arty_z7_10
   Description: Digilent Arty S7
@@ -191,6 +195,7 @@
   FPGA: iCE40UltraPlus UP5K
   Memory: NA
   Flash: AS
+  Constraints: iCEBreaker
 
 - ID: icebreaker-bitsy
   Description: iCEBreaker-bitsy
@@ -198,6 +203,9 @@
   FPGA: iCE40UltraPlus UP5K
   Memory: NA
   Flash: OK
+  Constraints:
+    - iCEBreaker-bitsy-v0
+    - iCEBreaker-bitsy-v1
 
 - ID: ice40_generic
   Description: icestick
@@ -205,6 +213,7 @@
   FPGA: iCE40 HX1k
   Memory: NA
   Flash: AS
+  Constraints: IceStick
 
 - ID: ice40_generic
   Description: iCE40-HX8K
@@ -212,6 +221,7 @@
   FPGA: iCE40 HX8k
   Memory: NT
   Flash: AS
+  Constraints: iCE40-HX8K
 
 - ID: ice40_generic
   Description: Olimex iCE40HX1K-EVB
@@ -219,6 +229,7 @@
   FPGA: iCE40 HX1k
   Memory: NT
   Flash: AS
+  Constraints: iCE40HX1K-EVB
 
 - ID: ice40_generic
   Description: Olimex iCE40HX8K-EVB
@@ -226,6 +237,7 @@
   FPGA: iCE40 HX8k
   Memory: NT
   Flash: AS
+  Constraints: iCE40HX8K-EVB
 
 - ID: ice40_generic
   Description: Icezum Alhambra II
@@ -233,6 +245,7 @@
   FPGA: iCE40 HX4k
   Memory: NT
   Flash: AS
+  Constraints: IceZumAlhambraII
 
 - ID: kc705
   Description: Xilinx KC705
@@ -240,6 +253,7 @@
   FPGA: Kintex7 xc7k325t
   Memory: OK
   Flash: NT
+  Constraints: KC705
 
 - ID: licheeTang
   Description: Sipeed Lichee Tang
@@ -282,6 +296,7 @@
   FPGA: ECP5 LFE5U-25F-8MG285C
   Memory: OK (JTAG)
   Flash: OK (DFU)
+  Constraints: OrangeCrab-r0.2
 
 - ID: pipistrello
   Description: Saanlima Pipistrello LX45
@@ -351,6 +366,11 @@
   FPGA: ECP5 LFE5U
   Memory: OK
   Flash: OK
+  Constraints:
+    - ULX3S-12F
+    - ULX3S-25F
+    - ULX3S-45F
+    - ULX3S-85F
 
 - ID: ulx3s_dfu
   Description: Radiona ULX3S DFU mode
@@ -400,3 +420,4 @@
   FPGA: zynq7000 xc7z020clg484
   Memory: OK
   Flash: NA
+  Constraints: ZedBoard

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -94,7 +94,8 @@ texinfo_documents = [
 # -- Sphinx.Ext.InterSphinx -----------------------------------------------
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
+    "python":      ("https://docs.python.org/3/", None),
+    "constraints": ("https://hdl.github.io/constraints", None)
 }
 
 # -- Sphinx.Ext.ExtLinks --------------------------------------------------


### PR DESCRIPTION
This is a follow-up of #160, related to #105.

An optional field, `Constraints`, is added to each item in `boards.yml`. `Constraints` can contain an string or a list of strings, matching the boad identifiers used in [hdl/constraints](https://github.com/hdl/constraints).

At the same time, an intersphinx mapping to hdl/constraints was added to the documentation configuration. When building the documentation, a new column is added to the boards compatibility table, which contains cross-references to [hdl.github.io/constraints/Data/Boards](https://hdl.github.io/constraints/Data/Boards). See [umarcor.github.io/openFPGALoader/compatibility/board](https://umarcor.github.io/openFPGALoader/compatibility/board).

@trabucayre, as discussed in https://github.com/trabucayre/openFPGALoader/issues/105#issuecomment-899657329, the purpose is each repo to can keep their own data/details. These "keywords" allow cross-referencing through interpshinx, as shown in this PR. Furthermore, after this PR is merged, we can use the `boards.yml` and `boards.py` files from this repo to enhance the documentation of hdl/constraints.

We can later improve this iteratively:

- Add misssing boards to hdl/constraints.
- Evaluate adding fields to the YAML here or there, and/or moving fields from one to the other.
- Update the layour in the site here, in order to show a section per board, instead of or apart from the table.
- Etc.