### PR TITLE
Add support for Gowin GW1NR-9C

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -50,6 +50,7 @@ Gowin:
      - GW1N-1
      - GW1N-4
      - GW1NR-9
+     - GW1NR-9C
      - GW1NS-2C
      - GW1NSR-4C
     URL: https://www.gowinsemi.com/en/product/detail/2/

--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -366,6 +366,13 @@
   Memory: OK
   Flash: IF/EF
 
+- ID: tangnano4k
+  Description: Sipeed Tang Nano 9K
+  URL: https://tangnano.sipeed.com/en/
+  FPGA: littleBee GW1NR-9C
+  Memory: OK
+  Flash: IF/EF
+
 - ID: tec0117
   Description: Trenz Gowin LittleBee (TEC0117)
   URL: https://shop.trenz-electronic.de/en/TEC0117-01-FPGA-Module-with-GOWIN-LittleBee-and-8-MByte-internal-SDRAM

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -158,6 +158,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("runber",          "", "ft232",      0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("tangnano",        "", "ch552_jtag", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("tangnano4k",      "", "ft2232",     0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("tangnano9k",      "", "ft2232",     0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("tec0117",         "", "ft2232",     0, 0, CABLE_DEFAULT),
 	JTAG_BITBANG_BOARD("ulx2s",   "", "ft232RL", 0, 0,
 			FT232RL_RI, FT232RL_DSR, FT232RL_CTS, FT232RL_DCD, CABLE_DEFAULT),

--- a/src/fsparser.cpp
+++ b/src/fsparser.cpp
@@ -165,7 +165,9 @@ int FsParser::parse()
 		case 0x1100381b: /* GW1N-4B   */
 			nb_line = 494;
 			break;
-		case 0x0100481b: /* GW1N-6    */
+		case 0x0100481b: /* GW1N-6(9C ES?) */
+		case 0x1100481b: /* GW1N-9C   */
+		case 0x0100581b: /* GW1N-9(ES)*/
 		case 0x1100581b: /* GW1N-9    */
 			nb_line = 712;
 			padding = 4;

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -116,6 +116,7 @@ static std::map <int, fpga_model> fpga_list = {
 
 	{0x0129a043, {"lattice", "XP2", "LFXP2-8E", 8}},
 
+	{0x0100481b, {"Gowin", "GW1N", "GW1N(R)-9C", 8}},
 	{0x0100581b, {"Gowin", "GW1N", "GW1NR-9", 8}},
 	{0x0900281B, {"Gowin", "GW1N", "GW1N-1", 8}},
 	{0x0120681b, {"Gowin", "GW1N", "GW1N-2", 8}},


### PR DESCRIPTION
The chip used by Sipeed Tang Nano 9K, GW1NR-LV9QN88PC6/I5, belongs to GW1NR-9C family.

Add support for it.