### PR TITLE
board: add tangnano1k

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -53,6 +53,7 @@ Gowin:
      - GW1NR-9C
      - GW1NS-2C
      - GW1NSR-4C
+     - GW1NZ-1
     URL: https://www.gowinsemi.com/en/product/detail/2/
     Memory: OK
     Flash: IF

--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -372,7 +372,7 @@
   URL: https://tangnano.sipeed.com/en/
   FPGA: littleBee GW1NZ-1
   Memory: OK
-  Flash: IF/EF
+  Flash: IF
 
 - ID: tangnano4k
   Description: Sipeed Tang Nano 4K

--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -367,6 +367,13 @@
   FPGA: littleBee GW1N-1
   Memory: OK
 
+- ID: tangnano1k
+  Description: Sipeed Tang Nano 1K
+  URL: https://tangnano.sipeed.com/en/
+  FPGA: littleBee GW1NZ-1
+  Memory: OK
+  Flash: IF/EF
+
 - ID: tangnano4k
   Description: Sipeed Tang Nano 4K
   URL: https://tangnano.sipeed.com/en/

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -159,6 +159,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("qmtechCycloneV",  "5ce223", "",     0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("runber",          "", "ft232",      0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("tangnano",        "", "ch552_jtag", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("tangnano1k",      "", "ft2232",     0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("tangnano4k",      "", "ft2232",     0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("tangnano9k",      "", "ft2232",     0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("tec0117",         "", "ft2232",     0, 0, CABLE_DEFAULT),

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -121,6 +121,7 @@ static std::map <int, fpga_model> fpga_list = {
 	{0x0900281B, {"Gowin", "GW1N", "GW1N-1", 8}},
 	{0x0120681b, {"Gowin", "GW1N", "GW1N-2", 8}},
 	{0x0100381B, {"Gowin", "GW1N", "GW1N-4", 8}},
+	{0x0100681b, {"Gowin", "GW1NZ", "GW1NZ-1", 8}},
 	{0x0300181b, {"Gowin", "GW1NS", "GW1NS-2C", 8}},
 	{0x0100981b, {"Gowin", "GW1NSR", "GW1NSR-4C", 8}},
 


### PR DESCRIPTION
Adds support for the [GW1NZ-1](https://www.gowinsemi.com/en/product/detail/46/) chip and the new [Tang Nano 1K](https://www.aliexpress.com/item/1005002551785169.html?spm=a2g0o.store_pc_groupList.8148356.2.78981d42dwD89o) board.

I'm not entirely sure about what's the purpose of the `Memory` and `Flash` fields in the `boards.yml` file (copy-pasted from `tangnano4k`) so they might not be set correctly.