### PR TITLE
ice40: Add override specifier to resolve compiler warnings

### DIFF
--- a/src/ice40.hpp
+++ b/src/ice40.hpp
@@ -23,7 +23,7 @@ class Ice40: public Device, SPIInterface {
 
 		void program(unsigned int offset, bool unprotect_flash) override;
 		bool program_cram(uint8_t *data, uint32_t length);
-		bool dumpFlash(uint32_t base_addr, uint32_t len);
+		bool dumpFlash(uint32_t base_addr, uint32_t len) override;
 		bool protect_flash(uint32_t len) override;
 		bool unprotect_flash() override;
 		/* not supported in SPI Active mode */
@@ -31,16 +31,16 @@ class Ice40: public Device, SPIInterface {
 		void reset() override;
 
 		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
-				uint32_t len) {
+				uint32_t len) override {
 			(void)cmd; (void)tx; (void)rx; (void)len;
 			return 0;
 		}
-		int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) {
+		int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) override {
 			(void)tx; (void)rx; (void)len;
 			return 0;
 		}
 		int spi_wait(uint8_t cmd, uint8_t mask, uint8_t cond,
-				uint32_t timeout, bool verbose = false) {
+				uint32_t timeout, bool verbose = false) override {
 			(void)cmd; (void)mask; (void)cond; (void)timeout; (void) verbose;
 			return 0;
 		}


### PR DESCRIPTION
The following compiler warnings are resolved by adding appropriate override specifiers:

In file included from openFPGALoader/src/ice40.cpp:6:
openFPGALoader/src/ice40.hpp:26:8: warning: 'dumpFlash' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
                bool dumpFlash(uint32_t base_addr, uint32_t len);
                     ^
openFPGALoader/src/device.hpp:46:16: note: overridden virtual function is here
                virtual bool dumpFlash(uint32_t base_addr, uint32_t len) {
                             ^
In file included from openFPGALoader/src/ice40.cpp:6:
openFPGALoader/src/ice40.hpp:34:7: warning: 'spi_put' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
                int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
                    ^
openFPGALoader/src/spiInterface.hpp:65:14: note: overridden virtual function is here
        virtual int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
                    ^
In file included from openFPGALoader/src/ice40.cpp:6:
openFPGALoader/src/ice40.hpp:39:7: warning: 'spi_put' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
                int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) {
                    ^
openFPGALoader/src/spiInterface.hpp:75:14: note: overridden virtual function is here
        virtual int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) = 0;
                    ^
In file included from openFPGALoader/src/ice40.cpp:6:
openFPGALoader/src/ice40.hpp:43:7: warning: 'spi_wait' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
                int spi_wait(uint8_t cmd, uint8_t mask, uint8_t cond,
                    ^
openFPGALoader/src/spiInterface.hpp:85:14: note: overridden virtual function is here
        virtual int spi_wait(uint8_t cmd, uint8_t mask, uint8_t cond,
                    ^
4 warnings generated.