### PR TITLE
spiFlash: Add --bulk-erase command line option

### DIFF
--- a/src/altera.hpp
+++ b/src/altera.hpp
@@ -57,6 +57,12 @@ class Altera: public Device, SPIInterface {
 		bool unprotect_flash() override {
 			return SPIInterface::unprotect_flash();
 		}
+		/*!
+		 * \brief bulk erase SPI flash
+		 */
+		bool bulk_erase_flash() override {
+			return SPIInterface::bulk_erase_flash();
+		}
 
 		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
 				uint32_t len) override;

--- a/src/anlogic.hpp
+++ b/src/anlogic.hpp
@@ -41,6 +41,13 @@ class Anlogic: public Device, SPIInterface {
 		}
 
 		/*!
+		 * \brief bulk erase SPI flash
+		 */
+		bool bulk_erase_flash() override {
+			return SPIInterface::bulk_erase_flash();
+		}
+
+		/*!
 		 * \brief dump len byte from base_addr from SPI flash
 		 * \param[in] base_addr: start offset
 		 * \param[in] len: dump len

--- a/src/colognechip.hpp
+++ b/src/colognechip.hpp
@@ -40,6 +40,8 @@ class CologneChip: public Device, SPIInterface {
 			printError("protect flash not supported"); return false;}
 		virtual bool unprotect_flash() override {
 			printError("unprotect flash not supported"); return false;}
+		virtual bool bulk_erase_flash() override {
+			printError("bulk erase flash not supported"); return false;}
 		void program(unsigned int offset, bool unprotect_flash) override;
 
 		int idCode() override {return 0;}

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -48,6 +48,7 @@ class Device {
 			printError("dump flash not supported"); return false;}
 		virtual bool protect_flash(uint32_t len) = 0;
 		virtual bool unprotect_flash() = 0;
+		virtual bool bulk_erase_flash() = 0;
 
 		virtual int  idCode() = 0;
 		virtual void reset();

--- a/src/efinix.hpp
+++ b/src/efinix.hpp
@@ -32,6 +32,8 @@ class Efinix: public Device {
 			printError("protect flash not supported"); return false;}
 		virtual bool unprotect_flash() override {
 			printError("unprotect flash not supported"); return false;}
+		virtual bool bulk_erase_flash() override {
+			printError("bulk erase flash not supported"); return false;}
 		/* not supported in SPI Active mode */
 		int idCode() override {return 0;}
 		void reset() override;

--- a/src/gowin.hpp
+++ b/src/gowin.hpp
@@ -34,6 +34,8 @@ class Gowin: public Device, SPIInterface {
 			printError("protect flash not supported"); return false;}
 		virtual bool unprotect_flash() override {
 			printError("unprotect flash not supported"); return false;}
+		virtual bool bulk_erase_flash() override {
+			printError("bulk erase flash not supported"); return false;}
 		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
 			uint32_t len) override;
 		int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) override;

--- a/src/ice40.cpp
+++ b/src/ice40.cpp
@@ -237,6 +237,26 @@ bool Ice40::unprotect_flash()
 	return post_flash_access();
 }
 
+bool Ice40::bulk_erase_flash()
+{
+	/* SPI access */
+	prepare_flash_access();
+	/* acess */
+	try {
+		SPIFlash flash(reinterpret_cast<SPIInterface *>(_spi), false, _verbose);
+		/* bulk erase flash */
+		if (flash.bulk_erase() == -1)
+			return false;
+	} catch (std::exception &e) {
+		printError("Fail");
+		printError(std::string(e.what()));
+		return false;
+	}
+
+	/* reload */
+	return post_flash_access();
+}
+
 bool Ice40::prepare_flash_access()
 {
 	/* SPI access: shutdown ICE40 */

--- a/src/ice40.hpp
+++ b/src/ice40.hpp
@@ -26,6 +26,7 @@ class Ice40: public Device, SPIInterface {
 		bool dumpFlash(uint32_t base_addr, uint32_t len) override;
 		bool protect_flash(uint32_t len) override;
 		bool unprotect_flash() override;
+		bool bulk_erase_flash() override;
 		/* not supported in SPI Active mode */
 		int idCode() override {return 0;}
 		void reset() override;

--- a/src/lattice.hpp
+++ b/src/lattice.hpp
@@ -47,6 +47,12 @@ class Lattice: public Device, SPIInterface {
 		bool unprotect_flash() override {
 			return SPIInterface::unprotect_flash();
 		}
+		/*!
+		 * \brief bulk erase SPI flash
+		 */
+		bool bulk_erase_flash() override {
+			return SPIInterface::bulk_erase_flash();
+		}
 
 		/* spi interface */
 		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,

--- a/src/spiFlash.cpp
+++ b/src/spiFlash.cpp
@@ -79,7 +79,7 @@ SPIFlash::SPIFlash(SPIInterface *spi, bool unprotect, int8_t verbose):
 int SPIFlash::bulk_erase()
 {
 	int ret, ret2 = 0;
-	uint32_t timeout=100000;
+	uint32_t timeout=1000000;
 	uint8_t bp = get_bp();
 	if (bp != 0) {
 		if (!_unprotect) {
@@ -96,7 +96,7 @@ int SPIFlash::bulk_erase()
 		return ret;
 	ret2 = _spi->spi_put(FLASH_CE, NULL, NULL, 0);
 	if (ret2 == 0)
-		ret2 = _spi->spi_wait(FLASH_RDSR, FLASH_RDSR_WIP, 0x00, timeout, true);
+		ret2 = _spi->spi_wait(FLASH_RDSR, FLASH_RDSR_WIP, 0x00, timeout);
 
 	if (bp != 0)
 		ret = enable_protection(bp);

--- a/src/spiInterface.cpp
+++ b/src/spiInterface.cpp
@@ -39,8 +39,8 @@ bool SPIInterface::protect_flash(uint32_t len)
 		SPIFlash flash(this, false, _spif_verbose);
 
 		/* configure flash protection */
-		ret = flash.enable_protection(len) != 0;
-		if (ret != 0)
+		ret = (flash.enable_protection(len) == 0);
+		if (!ret)
 			printError("Fail");
 		else
 			printSuccess("Done");
@@ -72,7 +72,7 @@ bool SPIInterface::unprotect_flash()
 		printInfo("unprotect_flash: ", false);
 		ret = (flash.disable_protection() == 0);
 		if (!ret)
-			printError("Fail " + std::to_string(ret));
+			printError("Fail");
 		else
 			printSuccess("Done");
 	} catch (std::exception &e) {

--- a/src/spiInterface.cpp
+++ b/src/spiInterface.cpp
@@ -85,6 +85,37 @@ bool SPIInterface::unprotect_flash()
 	return post_flash_access() && ret;
 }
 
+bool SPIInterface::bulk_erase_flash()
+{
+	bool ret = true;
+	printInfo("bulk_erase: ", false);
+
+	/* move device to spi access */
+	if (!prepare_flash_access()) {
+		printError("Fail");
+		return false;
+	}
+
+	/* spi flash access */
+	try {
+		SPIFlash flash(this, false, _spif_verbose);
+
+		/* bulk erase flash */
+		ret = (flash.bulk_erase() == 0);
+		if (!ret)
+			printError("Fail");
+		else
+			printSuccess("Done");
+	} catch (std::exception &e) {
+		printError("Fail");
+		printError(e.what());
+		ret = false;
+	}
+
+	/* reload bitstream */
+	return post_flash_access() && ret;
+}
+
 bool SPIInterface::write(uint32_t offset, uint8_t *data, uint32_t len,
 		bool unprotect_flash)
 {

--- a/src/spiInterface.hpp
+++ b/src/spiInterface.hpp
@@ -26,6 +26,7 @@ class SPIInterface {
 
 	bool protect_flash(uint32_t len);
 	bool unprotect_flash();
+	bool bulk_erase_flash();
 	/*!
 	 * \brief write len byte into flash starting at offset,
 	 *        optionnally verify after write and unprotect

--- a/src/xilinx.hpp
+++ b/src/xilinx.hpp
@@ -40,6 +40,12 @@ class Xilinx: public Device, SPIInterface {
 		bool unprotect_flash() override {
 			return SPIInterface::unprotect_flash();
 		}
+		/*!
+		 * \brief erase SPI flash blocks
+		 */
+		bool bulk_erase_flash() override {
+			return SPIInterface::bulk_erase_flash();
+		}
 
 		int idCode() override;
 		void reset() override;


### PR DESCRIPTION
Adds a --bulk-erase command line option for bulk erasure of SPI flash.

Sometimes I want to completely erase the SPI flash, to stop the FPGA loading the contents and reverting to internal SRAM configuration.

This branch is NOT ready for merging yet - there are errors reported after the bulk erase occurs.

I'm submitting this as a question - is this something that should be added to openFPGALoader, and is it worth my effort to debug the errors, or does this have no hope of ever being accepted, hence I'd just keep it as a local branch and live with the errors (since they happen after the erase is done).