### PR TITLE
Add Cyclone V 5CEFA5 in part database

### DIFF
--- a/src/part.hpp
+++ b/src/part.hpp
@@ -71,6 +71,7 @@ static std::map <int, fpga_model> fpga_list = {
 
 	{0x02b150dd, {"altera", "cyclone V", "5CEA2", 10}},
 	{0x02b050dd, {"altera", "cyclone V", "5CEBA4", 10}},
+	{0x02b220dd, {"altera", "cyclone V", "5CEFA5", 10}},
 	{0x02d020dd, {"altera", "cyclone V Soc", "5CSEBA6", 10}},
 	{0x02d010dd, {"altera", "cyclone V Soc", "5CSEMA4", 10}},
 	{0x02d120dd, {"altera", "cyclone V Soc", "5CSEMA5", 10}},


### PR DESCRIPTION
This pull request enable to program bitstream in sram for a QMTech Cyclone V Core Board 5CEFA5F23. 

I will try to add support for writing bitstream in flash in another pull request.

  