### PR TITLE
CMakeLists: fix general code styling, use dynamic linking on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 3.0)
 
 # set the project name
@@ -7,9 +6,9 @@ add_definitions(-DVERSION=\"v${PROJECT_VERSION}\")
 
 option(BUILD_STATIC "Whether or not to build with static libraries" OFF)
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
- set(ENABLE_UDEV OFF)
+	set(ENABLE_UDEV OFF)
 else()
- option(ENABLE_UDEV "use udev to search JTAG adapter from /dev/xx" ON)
+	option(ENABLE_UDEV "use udev to search JTAG adapter from /dev/xx" ON)
 endif()
 option(ENABLE_CMSISDAP "enable cmsis DAP interface (requires hidapi)" ON)
 option(USE_PKGCONFIG "Use pkgconfig to find libraries" ON)
@@ -32,13 +31,13 @@ add_definitions(-DDATA_DIR=\"${CMAKE_INSTALL_FULL_DATAROOTDIR}\")
 
 add_definitions(-DISE_DIR=\"${ISE_PATH}\")
 
-if(USE_PKGCONFIG)
+if (USE_PKGCONFIG)
 	find_package(PkgConfig REQUIRED)
 	pkg_check_modules(LIBFTDI REQUIRED libftdi1)
 	pkg_check_modules(LIBUSB REQUIRED libusb-1.0)
 	pkg_check_modules(HIDAPI hidapi-hidraw)
 	# if hidraw not found try with libusb
-	if(NOT HIDAPI_FOUND)
+	if (NOT HIDAPI_FOUND)
 		pkg_check_modules(HIDAPI hidapi-libusb)
 	endif()
 	# zlib support (gzip)
@@ -53,7 +52,7 @@ if(USE_PKGCONFIG)
 		endif()
 	endif(NOT ZLIB_FOUND)
 
-	if(ENABLE_UDEV)
+	if (ENABLE_UDEV)
 		pkg_check_modules(LIBUDEV libudev)
 		if (LIBUDEV_FOUND)
 			add_definitions(-DUSE_UDEV)
@@ -159,6 +158,11 @@ set(OPENFPGALOADER_HEADERS
 	src/colognechipCfgParser.hpp
 )
 
+link_directories(
+	${LIBUSB_LIBRARY_DIRS}
+	${LIBFTDI_LIBRARY_DIRS}
+)
+
 add_executable(openFPGALoader
 	${OPENFPGALOADER_SOURCE}
 	${OPENFPGALOADER_HEADERS}
@@ -169,16 +173,6 @@ include_directories(
 	${LIBFTDI_INCLUDE_DIRS}
 )
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	find_library(LIBFTDI1STATIC libftdi1.a REQUIRED)
-	find_library(LIBUSB1STATIC libusb-1.0.a REQUIRED)
-	target_link_libraries(openFPGALoader ${LIBFTDI1STATIC} ${LIBUSB1STATIC})
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework CoreFoundation -framework IOKit -framework Security")
-	link_directories(/usr/local/lib)
-	target_include_directories(openFPGALoader PRIVATE /usr/local/include)
-	set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-	set_target_properties(openFPGALoader PROPERTIES LINK_SEARCH_END_STATIC 1)
-else()
 target_link_libraries(openFPGALoader
 	${LIBUSB_LIBRARIES}
 	${LIBFTDI_LIBRARIES}
@@ -194,9 +188,9 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	add_definitions(-DATTACH_KERNEL)
 endif()
 
-if(ENABLE_UDEV)
-include_directories(${LIBUDEV_INCLUDE_DIRS})
-target_link_libraries(openFPGALoader ${LIBUDEV_LIBRARIES})
+if (ENABLE_UDEV)
+	include_directories(${LIBUDEV_INCLUDE_DIRS})
+	target_link_libraries(openFPGALoader ${LIBUDEV_LIBRARIES})
 endif()
 
 if (BUILD_STATIC)
@@ -204,16 +198,16 @@ if (BUILD_STATIC)
 endif()
 
 if (ENABLE_CMSISDAP)
-if (HIDAPI_FOUND)
-	include_directories(${HIDAPI_INCLUDE_DIRS})
-	target_link_libraries(openFPGALoader ${HIDAPI_LIBRARIES})
-	add_definitions(-DENABLE_CMSISDAP=1)
-	target_sources(openFPGALoader PRIVATE src/cmsisDAP.cpp)
-	list (APPEND OPENFPGALOADER_HEADERS src/cmsisDAP.hpp)
-	message("cmsis_dap support enabled")
-else()
-	message("hidapi-libusb not found: cmsis_dap support disabled")
-endif()
+	if (HIDAPI_FOUND)
+		include_directories(${HIDAPI_INCLUDE_DIRS})
+		target_link_libraries(openFPGALoader ${HIDAPI_LIBRARIES})
+		add_definitions(-DENABLE_CMSISDAP=1)
+		target_sources(openFPGALoader PRIVATE src/cmsisDAP.cpp)
+		list (APPEND OPENFPGALOADER_HEADERS src/cmsisDAP.hpp)
+		message("cmsis_dap support enabled")
+	else()
+		message("hidapi-libusb not found: cmsis_dap support disabled")
+	endif()
 endif(ENABLE_CMSISDAP)
 
 if (ZLIB_FOUND)
@@ -222,7 +216,6 @@ if (ZLIB_FOUND)
 	add_definitions(-DHAS_ZLIB=1)
 else()
 	message("zlib library not found: can't flash intel/altera devices")
-endif()
 endif()
 
 if (LINK_CMAKE_THREADS)


### PR DESCRIPTION
* Making the indentation even across the whole file
* Use dynamic linking on macOS and fix its pkg-config usage in the process. This should render openFPGALoader agnostic to the location of Homebrew's prefix, and solve compatibility issues with MacPorts. It also removes all the dirty Make hacks which were necessary for macOS.