### PR TITLE
doc/guide: Add instructions for manual installation on macOS

### DIFF
--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -134,6 +134,19 @@ openFPGALoader is available as a `Homebrew <https://brew.sh>`__ formula:
 
     brew install openfpgaloader
 
+Alternatively, if you want to build it from hand:
+
+.. code-block:: bash
+
+    brew install --only-dependencies openfpgaloader
+    brew install cmake pkg-config zlib
+    git clone https://github.com/trabucayre/openFPGALoader
+    cd openFPGALoader
+    mkdir build
+    cd build
+    cmake ..
+    make -j
+
 Windows
 =======
 


### PR DESCRIPTION
This PR adds instructions explaining how to install openFPGALoader on macOS from sources, using packages from Homebrew.