### PR TITLE
part: Add kintex7 variant xc7k410t

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -177,6 +177,7 @@ Xilinx:
     Model:
       - xc7k160t
       - xc7k325t
+      - xc7k410t
     URL: https://www.xilinx.com/products/silicon-devices/fpga/kintex-7.html#productTable
     Memory: OK
     Flash: OK

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -29,6 +29,7 @@ static std::map <int, fpga_model> fpga_list = {
 
 	{0x0364c093, {"xilinx", "kintex7", "xc7k160t", 6}},
 	{0x03651093, {"xilinx", "kintex7", "xc7k325t", 6}},
+	{0x03656093, {"xilinx", "kintex7", "xc7k410t", 6}},
 
 	{0x01414093, {"xilinx", "spartan3", "xc3s200",  6}},
 


### PR DESCRIPTION
Hi!

This PR adds support for the xc7k410t variant of the kintex 7. This is the fpga part used in the USRP X310. I've tested flashing the SRAM on this device using the integrated Digilent JTAG cable. I've also tested the existing xc7k325t support with a USRP X300 and verified flashing the SRAM works as well.

Please let me know if y'all have any feedback. Thanks for such a cool project!