### PR TITLE
gatemate: fix failed signal polarity and update documentation

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -96,14 +96,14 @@
 
 - ID: gatemate_evb_jtag
   Description: Cologne Chip GateMate FPGA Evaluation Board (JTAG mode)
-  URL: https://colognechip.com/programmable-logic/gatemate/
+  URL: https://colognechip.com/programmable-logic/gatemate-evaluation-board/
   FPGA: Cologne Chip GateMate Series
   Memory: OK
   Flash: OK
 
 - ID: gatemate_evb_spi
   Description: Cologne Chip GateMate FPGA Evaluation Board (SPI mode)
-  URL: https://colognechip.com/programmable-logic/gatemate/
+  URL: https://colognechip.com/programmable-logic/gatemate-evaluation-board/
   FPGA: Cologne Chip GateMate Series
   Memory: OK
   Flash: OK

--- a/doc/vendors/colognechip.rst
+++ b/doc/vendors/colognechip.rst
@@ -17,7 +17,7 @@ Supported configuration files are bitfiles ``*.bit`` and it's ASCII equivalents 
 JTAG Configuration
 ------------------
 
-Performs an active hardware reset and writes the configuration into the FPGA latches via JTAG. The configuration mode pins ``CFG_MD[3:0]`` must be set to 0xF0 (JTAG).
+Performs an active hardware reset and writes the configuration into the FPGA latches via JTAG. The configuration mode pins ``CFG_MD[3:0]`` must be set to 0xC (JTAG).
 
 1. Program using Evaluation Board:
 
@@ -34,7 +34,7 @@ Performs an active hardware reset and writes the configuration into the FPGA lat
 SPI Configuration
 -----------------
 
-Performs an active hardware reset and writes the configuration into the FPGA latches via SPI. The configuration mode pins ``CFG_MD[3:0]`` must be set to 0x40 (SPI passive).
+Performs an active hardware reset and writes the configuration into the FPGA latches via SPI. The configuration mode pins ``CFG_MD[3:0]`` must be set to 0x4 (SPI passive).
 
 1. Program using Evaluation Board:
 
@@ -51,7 +51,7 @@ Performs an active hardware reset and writes the configuration into the FPGA lat
 JTAG Flash Access
 -----------------
 
-It is possible to access external flashes via the internal JTAG-SPI-bypass. The configuration mode pins ``CFG_MD[3:0]`` must be set to 0xF0 (JTAG). Note that the FPGA will not start automatically.
+It is possible to access external flashes via the internal JTAG-SPI-bypass. The configuration mode pins ``CFG_MD[3:0]`` must be set to 0xC (JTAG). Note that the FPGA will not start automatically.
 
 1. Write to flash using Evaluation Board:
 
@@ -74,7 +74,7 @@ The `offset` parameter can be used to store data at any point in the flash, e.g.
 SPI Flash Access
 ----------------
 
-If the programming device and FPGA share the same SPI signals, it is possible to hold the FPGA in reset and write data to the flash. The configuration mode can be set as desired. If the FPGA should start from the external memory after reset, the configuration mode pins ``CFG_MD[3:0]`` set to 0x00 (SPI active).
+If the programming device and FPGA share the same SPI signals, it is possible to hold the FPGA in reset and write data to the flash. The configuration mode can be set as desired. If the FPGA should start from the external memory after reset, the configuration mode pins ``CFG_MD[3:0]`` set to 0x0 (SPI active).
 
 1. Write to flash using Evaluation Board:
 

--- a/src/colognechip.hpp
+++ b/src/colognechip.hpp
@@ -24,7 +24,7 @@ class CologneChip: public Device, SPIInterface {
 	public:
 		CologneChip(FtdiSpi *spi, const std::string &filename,
 			const std::string &file_type, Device::prog_type_t prg_type,
-			uint16_t rstn_pin, uint16_t done_pin, uint16_t failn_pin, uint16_t oen_pin,
+			uint16_t rstn_pin, uint16_t done_pin, uint16_t fail_pin, uint16_t oen_pin,
 			bool verify, int8_t verbose);
 		CologneChip(Jtag* jtag, const std::string &filename,
 			const std::string &file_type, Device::prog_type_t prg_type,
@@ -64,7 +64,7 @@ class CologneChip: public Device, SPIInterface {
 		FtdiJtagMPSSE *_ftdi_jtag = NULL;
 		uint16_t _rstn_pin;
 		uint16_t _done_pin;
-		uint16_t _failn_pin;
+		uint16_t _fail_pin;
 		uint16_t _oen_pin;
 };
 


### PR DESCRIPTION
This pull request ensures compatibility with the final evaluation board version. More info, datasheet and schematics are available [here](https://colognechip.com/programmable-logic/gatemate-evaluation-board/).

Short overview:
* CFG_FAILED signal is no longer inverted
* minor fix in CFG_MD settings in `doc/vendors/colognechip.rst`
* update evaluation board URLs in `doc/boards.yml`

Thanks!