### PR TITLE
Add skip sram cmd

### DIFF
--- a/src/altera.cpp
+++ b/src/altera.cpp
@@ -25,9 +25,10 @@
 
 Altera::Altera(Jtag *jtag, const std::string &filename,
 	const std::string &file_type, Device::prog_type_t prg_type,
-	const std::string &device_package, bool verify, int8_t verbose):
+	const std::string &device_package, bool verify, int8_t verbose,
+	bool skip_load_bridge):
 	Device(jtag, filename, file_type, verify, verbose),
-	SPIInterface(filename, verbose, 256, verify),
+	SPIInterface(filename, verbose, 256, verify, skip_load_bridge),
 	_svf(_jtag, _verbose), _device_package(device_package),
 	_vir_addr(0x1000), _vir_length(14)
 {
@@ -146,6 +147,16 @@ void Altera::programMem(RawParser &_bit)
 	_jtag->toggleClk(1000000/clk_period);
 	/* -> idle */
 	_jtag->set_state(Jtag::RUN_TEST_IDLE);
+}
+
+
+bool Altera::prepare_flash_access()
+{
+	if (_skip_load_bridge) {
+		printInfo("Skip loading bridge for spiOverjtag");
+		return true;
+	}
+	return load_bridge();
 }
 
 bool Altera::load_bridge()

--- a/src/altera.hpp
+++ b/src/altera.hpp
@@ -20,7 +20,8 @@ class Altera: public Device, SPIInterface {
 				const std::string &file_type,
 				Device::prog_type_t prg_type,
 				const std::string &device_package,
-				bool verify, int8_t verbose);
+				bool verify, int8_t verbose,
+				bool skip_load_bridge);
 		~Altera();
 
 		void programMem(RawParser &_bit);
@@ -64,7 +65,7 @@ class Altera: public Device, SPIInterface {
 				uint32_t timeout, bool verbose = false) override;
 
 	protected:
-		bool prepare_flash_access() override {return load_bridge();}
+		bool prepare_flash_access() override;
 		bool post_flash_access() override {reset(); return true;}
 
 	private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,7 @@ struct arguments {
 	uint32_t protect_flash;
 	bool unprotect_flash;
 	string flash_sector;
+	bool skip_load_bridge;
 };
 
 int parse_opt(int argc, char **argv, struct arguments *args, jtag_pins_conf_t *pins_config);
@@ -84,7 +85,7 @@ int main(int argc, char **argv)
 	struct arguments args = {0, false, false, false, 0, "", "", "-", "", -1,
 			0, false, "-", false, false, false, false, Device::PRG_NONE, false,
 			false, false, "", "", "", -1, 0, false, -1, 0, 0, "127.0.0.1",
-			0, false, ""};
+			0, false, "", false};
 	/* parse arguments */
 	try {
 		if (parse_opt(argc, argv, &args, &pins_config))
@@ -466,7 +467,8 @@ int main(int argc, char **argv)
 				args.prg_type, args.fpga_part, args.verify, args.verbose);
 		} else if (fab == "altera") {
 			fpga = new Altera(jtag, args.bit_file, args.file_type,
-				args.prg_type, args.fpga_part, args.verify, args.verbose);
+				args.prg_type, args.fpga_part, args.verify, args.verbose,
+				args.skip_load_bridge);
 		} else if (fab == "anlogic") {
 			fpga = new Anlogic(jtag, args.bit_file, args.file_type,
 				args.prg_type, args.verify, args.verbose);
@@ -634,6 +636,8 @@ int parse_opt(int argc, char **argv, struct arguments *args, jtag_pins_conf_t *p
 				cxxopts::value<bool>(quiet))
 			("r,reset",   "reset FPGA after operations",
 				cxxopts::value<bool>(args->reset))
+			("skip-load-bridge", "skip writing bridge to SRAM when in write-flash mode",
+				cxxopts::value<bool>(args->skip_load_bridge))
 			("spi",   "SPI mode (only for FTDI in serial mode)",
 				cxxopts::value<bool>(args->spi))
 			("unprotect-flash",   "Unprotect flash blocks",

--- a/src/spiInterface.cpp
+++ b/src/spiInterface.cpp
@@ -11,13 +11,14 @@
 #include "spiFlash.hpp"
 
 SPIInterface::SPIInterface():_spif_verbose(0), _spif_rd_burst(0),
-	_spif_verify(false)
+	_spif_verify(false), _skip_load_bridge(false)
 {}
 
 SPIInterface::SPIInterface(const std::string &filename, uint8_t verbose,
-		uint32_t rd_burst, bool verify):
+		uint32_t rd_burst, bool verify, bool skip_load_bridge):
 	_spif_verbose(verbose), _spif_rd_burst(rd_burst),
-	_spif_verify(verify), _spif_filename(filename)
+	_spif_verify(verify), _skip_load_bridge(skip_load_bridge),
+	_spif_filename(filename)
 {}
 
 /* spiFlash generic acces */

--- a/src/spiInterface.hpp
+++ b/src/spiInterface.hpp
@@ -20,7 +20,7 @@ class SPIInterface {
  public:
 	SPIInterface();
 	SPIInterface(const std::string &filename, uint8_t verbose,
-			uint32_t rd_burst, bool verify);
+			uint32_t rd_burst, bool verify, bool skip_load_bridge = false);
 	virtual ~SPIInterface() {}
 
 	bool protect_flash(uint32_t len);
@@ -97,6 +97,7 @@ class SPIInterface {
 	uint8_t _spif_verbose;
 	uint32_t _spif_rd_burst;
 	bool _spif_verify;
+	bool _skip_load_bridge;
  private:
 	std::string _spif_filename;
 


### PR DESCRIPTION
Ref #221

Just a first quick approach (implemented only for Altera). Do you think this is the right direction?
Beside the added cmd line args a significant change is moving prepare_flash_access().

Other possbile ways I can see would be to add different ops to prog_type_t.