### PR TITLE
Add initial support for ZCU106 development board

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -535,6 +535,13 @@
   Memory: OK
   Flash: NA
 
+- ID: zcu106
+  Description: Xilinx ZCU106
+  URL: https://www.xilinx.com/products/boards-and-kits/zcu106.html
+  FPGA: zynqMPSoC XCZU7EV
+  Memory: OK
+  Flash: NA
+
 - ID: zedboard
   Description: Avnet ZedBoard
   URL: https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -190,6 +190,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("titanium_ti60_f225_jtag", "","efinix_jtag_ft4232",  0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("zc706",           "xc7z045ffg900", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("zcu102",          "xczu9egffvb1156", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("zcu106",          "xczu9egffvb1156", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("zedboard",        "xc7z020clg484", "digilent_hs2", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("papilio_one",     "xc3s500evq100", "papilio", 0, 0, CABLE_DEFAULT),
 };

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -70,10 +70,12 @@ static std::map <int, fpga_model> fpga_list = {
 	{0x08e22126, {"xilinx", "zynqmp_cfgn", "xczu2cg", 4}},
 	{0x08e70126, {"xilinx", "zynqmp_cfgn", "xczu9eg", 4}},
 	{0x08e80126, {"xilinx", "zynqmp_cfgn","xczu11eg", 4}},
+	{0x08e60126, {"xilinx", "zynqmp_cfgn", "xczu7ev", 4}},
 
 	{0x04711093, {"xilinx", "zynqmp",      "xczu2cg", 6}},
 	{0x04738093, {"xilinx", "zynqmp",      "xczu9eg", 6}},
 	{0x04740093, {"xilinx", "zynqmp",     "xczu11eg", 6}},
+	{0x04730093, {"xilinx", "zynqmp",      "xczu7ev", 6}},
 
 	{0x020f20dd, {"altera", "cyclone III/IV", "EP3C16/EP4CE15", 10}},
 


### PR DESCRIPTION
This works as expected for a bare-bones "hello world" bitstream (tying LEDs to switches) on my ZCU106 board.