### PR TITLE
fix(part.hpp): use uint32_t instead of int for fpga_list index

### DIFF
--- a/src/part.hpp
+++ b/src/part.hpp
@@ -6,6 +6,7 @@
 #ifndef PART_HPP
 #define PART_HPP
 
+#include <cstdint>
 #include <map>
 #include <string>
 
@@ -17,7 +18,7 @@ typedef struct {
 } fpga_model;
 
 /* Highest nibble (version) must always be set to 0 */
-static std::map <int, fpga_model> fpga_list = {
+static std::map <uint32_t, fpga_model> fpga_list = {
 	{0x0a014c35, {"anlogic", "eagle s20", "EG4S20BG256", 8}},
 	{0x00004c37, {"anlogic", "elf2", "EF2M45", 8}},
 


### PR DESCRIPTION
This resulted in an error with GCC 12:

```
In file included from src/main.cpp:29:
src/part.hpp:148:1: error: narrowing conversion of ‘2165379139’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
  148 | };
      | ^
```