### PR TITLE
cmsisDAP: fix crash in case hid device cannot be opened

### DIFF
--- a/src/cmsisDAP.cpp
+++ b/src/cmsisDAP.cpp
@@ -144,6 +144,10 @@ CmsisDAP::CmsisDAP(int vid, int pid, uint8_t verbose):_verbose(verbose),
 		_serial_number = wstring(dev_found[_device_idx]->serial_number);
 	/* open the device */
 	_dev = hid_open_path(dev_found[_device_idx]->path);
+	if (!_dev) {
+		throw std::runtime_error(
+				std::string("Couldn't open device. Check permissions for ") + dev_found[_device_idx]->path);
+	}
 	/* cleanup enumeration */
 	hid_free_enumeration(devs);
 


### PR DESCRIPTION
My user has permissions for the USB device but not for the hidraw device. This won't work, of course, but it shouldn't crash either.

Old behaviour:

```
$ ./openFPGALoader -c cmsisdap /dev/null
Found 1 compatible device:
 0x0d28 0x0204 DAPLink CMSIS-DAP
Segmentation fault (core dumped)
```

New behaviour:

```
$ ./openFPGALoader -c cmsisdap /dev/null
Found 1 compatible device:
 0x0d28 0x0204 DAPLink CMSIS-DAP
JTAG init failed with: Couldn't open device. Check permissions for /dev/hidraw2
```

Additional information:

```
$ ls -l /dev/hidraw2
crw------- 1 root root 245, 2 Jul  2 16:21 /dev/hidraw2
$ lsusb|grep 0204
Bus 003 Device 021: ID 0d28:0204 NXP ARM mbed
$ ls -l /dev/bus/usb/003/021
crw-rw-r-- 1 root dialout 189, 276 Jul  2 16:21 /dev/bus/usb/003/021
```

I haven't applied `99-openfpgaloader.rules` yet because I had already added udev rules for another tool (ecpdap).