### PR TITLE
cmsisDAP: better error message if support is not enabled

### DIFF
--- a/src/jtag.cpp
+++ b/src/jtag.cpp
@@ -115,15 +115,21 @@ void Jtag::init_internal(cable_t &cable, const string &dev, const string &serial
 		_jtag = new UsbBlaster(cable.config.vid, cable.config.pid,
 				firmware_path, _verbose);
 		break;
-#ifdef ENABLE_CMSISDAP
 	case MODE_CMSISDAP:
+#ifdef ENABLE_CMSISDAP
 		_jtag = new CmsisDAP(cable.config.vid, cable.config.pid, _verbose);
 		break;
+#else
+		std::cerr << "Jtag: support for cmsisdap was not enabled at compile time" << std::endl;
+		throw std::exception();
 #endif
-#ifdef ENABLE_XVC_CLIENT
 	case MODE_XVC_CLIENT:
+#ifdef ENABLE_XVC_CLIENT
 		_jtag = new XVC_client(ip_adr, clkHZ, _verbose);
 		break;
+#else
+		std::cerr << "Jtag: support for xvc-client was not enabled at compile time" << std::endl;
+		throw std::exception();
 #endif
 	default:
 		std::cerr << "Jtag: unknown cable type" << std::endl;


### PR DESCRIPTION
before:

```
$ ./openFPGALoader -c cmsisdap /dev/null
Jtag: unknown cable type
JTAG init failed with: std::exception
```

after:

```
$ ./openFPGALoader -c cmsisdap /dev/null
Jtag: support for cmsisdap was not enabled at compile time
JTAG init failed with: std::exception
```

It took me a while to realize that the error was not due to a typo or misunderstanding. NixOS is building it without hidapi so support for cmsisdap is automatically disabled.