### PR TITLE
Limit automatic read burst length to 64K

### DIFF
--- a/src/spiFlash.cpp
+++ b/src/spiFlash.cpp
@@ -382,8 +382,11 @@ int SPIFlash::erase_and_prog(int base_addr, uint8_t *data, int len)
 bool SPIFlash::verify(const int &base_addr, const uint8_t *data,
 		const int &len, int rd_burst)
 {
-	if (rd_burst == 0)
+	if (rd_burst == 0) {
 		rd_burst = len;
+		if (rd_burst > 65536)
+			rd_burst = 65536;
+	}
 
 	printInfo("Verifying write (May take time)");
 

--- a/src/spiFlashdb.hpp
+++ b/src/spiFlashdb.hpp
@@ -177,6 +177,19 @@ static std::map <uint32_t, flash_t> flash_list = {
 		.bp_len = 0,
 		.bp_offset = {0, 0, 0, 0}}
 	},
+	{0xBF2643, {
+		.manufacturer = "microchip",
+		.model = "SST26VF064B",
+		.nr_sector = 128,
+		.sector_erase = true,
+		.subsector_erase = true,
+		.has_extended = false,
+		.tb_otp = false,
+		.tb_offset = 0,
+		.tb_register = NONER,
+		.bp_len = 0,
+		.bp_offset = {0, 0, 0, 0}}
+	},
 	{0x9d6016, {
 		.manufacturer = "ISSI",
 		.model = "IS25LP032",


### PR DESCRIPTION
Reading of very large binaries (e.g. 32 MB) can cause stack overflow.
Put a reasonable limit on read burst length.