### PR TITLE
msys2: Fix windows paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ set(OPENFPGALOADER_SOURCE
 	src/jlink.cpp
 	src/lattice.cpp
 	src/progressBar.cpp
+	src/pathHelper.cpp
 	src/fsparser.cpp
 	src/mcsParser.cpp
 	src/ftdispi.cpp
@@ -138,6 +139,7 @@ set(OPENFPGALOADER_HEADERS
 	src/ice40.hpp
 	src/ihexParser.hpp
 	src/progressBar.hpp
+	src/pathHelper.hpp
 	src/rawParser.hpp
 	src/usbBlaster.hpp
 	src/bitparser.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,6 @@ set(OPENFPGALOADER_SOURCE
 	src/jlink.cpp
 	src/lattice.cpp
 	src/progressBar.cpp
-	src/pathHelper.cpp
 	src/fsparser.cpp
 	src/mcsParser.cpp
 	src/ftdispi.cpp
@@ -139,7 +138,6 @@ set(OPENFPGALOADER_HEADERS
 	src/ice40.hpp
 	src/ihexParser.hpp
 	src/progressBar.hpp
-	src/pathHelper.hpp
 	src/rawParser.hpp
 	src/usbBlaster.hpp
 	src/bitparser.hpp
@@ -198,6 +196,9 @@ target_link_libraries(openFPGALoader
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 	# winsock provides ntohs
 	target_link_libraries(openFPGALoader ws2_32)
+	
+	target_sources(openFPGALoader PRIVATE src/pathHelper.cpp)	
+	list(APPEND OPENFPGALOADER_HEADERS src/pathHelper.hpp)
 endif()
 
 # libusb_attach_kernel_driver is only available on Linux.

--- a/scripts/msys2/PKGBUILD
+++ b/scripts/msys2/PKGBUILD
@@ -27,7 +27,7 @@ build() {
     -G "MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     ../../../..
-  cmake --build .
+  MSYS2_ARG_CONV_EXCL="-DDATA_DIR=" cmake --build .
 }
 
 check() {

--- a/src/altera.cpp
+++ b/src/altera.cpp
@@ -13,8 +13,10 @@
 #include "device.hpp"
 #include "epcq.hpp"
 #include "progressBar.hpp"
-#include "pathHelper.hpp"
 #include "rawParser.hpp"
+#if defined (_WIN64) || defined (_WIN32)
+#include "pathHelper.hpp"
+#endif
 
 #define IDCODE 6
 #define USER0  0x0C

--- a/src/altera.cpp
+++ b/src/altera.cpp
@@ -13,6 +13,7 @@
 #include "device.hpp"
 #include "epcq.hpp"
 #include "progressBar.hpp"
+#include "pathHelper.hpp"
 #include "rawParser.hpp"
 
 #define IDCODE 6
@@ -179,6 +180,11 @@ bool Altera::load_bridge()
 	bitname += _device_package + ".rbf.gz";
 #else
 	bitname += _device_package + ".rbf";
+#endif
+
+#if defined (_WIN64) || defined (_WIN32)
+	/* Convert relative path embedded at compile time to an absolute path */
+	bitname = PathHelper::absolutePath(bitname);
 #endif
 
 	std::cout << "use: " << bitname << std::endl;

--- a/src/pathHelper.cpp
+++ b/src/pathHelper.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2022 Greg Davill <greg.davill@gmail.com>
+ */
+
+#if defined (_WIN64) || defined (_WIN32)
+#include "pathHelper.hpp"
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <array>
+#include <regex>
+
+std::string PathHelper::absolutePath(std::string input_path) {
+
+    /* Attempt to execute cygpath */
+    std::string cmd = std::string("cygpath -m " + input_path);
+
+    std::array<char, 128> buffer;
+    std::string result;
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
+    if (!pipe) {
+        /* If cygpath fails to run, return original path */
+        return input_path;
+    }
+    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+        result += buffer.data();
+    }
+
+    /* Trim trailing newline */
+    static const std::regex tws{"[[:space:]]*$", std::regex_constants::extended};
+    return std::regex_replace(result, tws, "");
+}
+
+#endif

--- a/src/pathHelper.hpp
+++ b/src/pathHelper.hpp
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2022 Greg Davill <greg.davill@gmail.com>
+ */
+
+#if defined (_WIN64) || defined (_WIN32)
+#include <string>
+
+class PathHelper{
+    public:
+        static std::string absolutePath(std::string input_path);
+};
+#endif

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -24,7 +24,9 @@
 #include "xilinxMapParser.hpp"
 #include "part.hpp"
 #include "progressBar.hpp"
+#if defined (_WIN64) || defined (_WIN32)
 #include "pathHelper.hpp"
+#endif
 
 Xilinx::Xilinx(Jtag *jtag, const std::string &filename,
 	const std::string &file_type,

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -24,6 +24,7 @@
 #include "xilinxMapParser.hpp"
 #include "part.hpp"
 #include "progressBar.hpp"
+#include "pathHelper.hpp"
 
 Xilinx::Xilinx(Jtag *jtag, const std::string &filename,
 	const std::string &file_type,
@@ -322,6 +323,11 @@ bool Xilinx::load_bridge()
 	// DATA_DIR is defined at compile time.
 	std::string bitname = DATA_DIR "/openFPGALoader/spiOverJtag_";
 	bitname += _device_package + ".bit.gz";
+
+#if defined (_WIN64) || defined (_WIN32)
+	/* Convert relative path embedded at compile time to an absolute path */
+	bitname = PathHelper::absolutePath(bitname);
+#endif
 
 	std::cout << "use: " << bitname << std::endl;
 


### PR DESCRIPTION
Fixes #262 

Following the example from msys2 (https://www.msys2.org/wiki/Porting/) "Hard-coded paths and relocation"
> Sometimes these paths are baked into shell scripts or pkg-config's .pc files. In that case, you should use sed in the PKGBUILD package() function to correct this back to the msys2 version of the path. 

The package step can strip the `D:/a/msys64/` or equivalent prefix that's added at compile time.

```
 -- Version installed from msys2 packages
$ strings /mingw64/bin/openFPGALoader.exe | grep mingw64/share
D:/a/msys64/mingw64/share/openFPGALoader/spiOverJtag_

 -- Version installed from this PRs CI build
$ strings /c/Users/greg/Downloads/openFPGALoader | grep mingw64/share
/mingw64/share/openFPGALoader/spiOverJtag_
```