### PR TITLE
ALINX AX516 board.

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -27,6 +27,13 @@
   Memory: OK
   Flash: OK
   
+- ID: alinx_ax516
+  Description: ALINX AX516
+  URL: https://www.alinx.com/en/detail/281
+  FPGA: Spartan6 xc6slx16csg324
+  Memory: OK
+  Flash: OK
+
 - ID: arty_a7_35t
   Description: Digilent Arty A7
   URL: https://reference.digilentinc.com/reference/programmable-logic/arty-a7/start

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -114,6 +114,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("arty_s7_50",      "xc7s50csga324",  "digilent", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("arty_z7_10",      "xc7z010clg400",  "digilent", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("arty_z7_20",      "xc7z020clg400",  "digilent", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("alinx_ax516",     "xc6slx16csg324", "",         0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("axu2cga",         "xczu2cg",        "",         0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("basys3",          "xc7a35tcpg236",  "digilent", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("cmod_s7",         "xc7s25csga225",  "digilent", 0, 0, CABLE_DEFAULT),


### PR DESCRIPTION
I'd like to report success in programming an ALINX AX516 Spartan-6 FPGA Development Board.

Programming just worked out of the box!  Thanks!

./openFPGALoader -v -v -c ft232 someproj.bit

gives the following output:

```
found 1 devices
index 0:
	idcode 0x4002093
	manufacturer xilinx
	family spartan6
	model  xc6slx16
	irlength 6
File type : bit
```

I am programming it with an ALINX AL321 USB cable.  (Since external, I did not specify ft232 it in `board.hpp`, is that correct?)

Writing to flash also works (now with `-b alinx_ax516`), and tells:

```
Detected: Winbond W25Q128 256 sectors size: 128Mb
```