### PR TITLE
Add initial support for the Xilinx VCU118 board

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -203,6 +203,13 @@ Xilinx:
     Memory: OK
     Flash: NA
 
+  - Description: Virtex UltraScale+
+    Model:
+      - xcvu9p
+    URL: https://www.xilinx.com/products/silicon-devices/fpga/virtex-ultrascale-plus.html#productTable
+    Memory: OK
+    Flash: NA
+
   - Description: Spartan 3
     Model:
       - xc3s200

--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -26,14 +26,14 @@
   FPGA: Artix xc7a35tftg256
   Memory: OK
   Flash: OK
-  
+
 - ID: alchitry_au_plus
   Description: Alchitry Au+ (Plus)
   URL: https://www.sparkfun.com/products/17514
   FPGA: Artix xc7a100tftg256
   Memory: OK
   Flash: OK
-  
+
 - ID: alinx_ax516
   Description: ALINX AX516
   URL: https://www.alinx.com/en/detail/281
@@ -641,5 +641,12 @@
   Description: Digilent Zybo Z7-20
   URL: https://reference.digilentinc.com/reference/programmable-logic/zybo-z7/start
   FPGA: zynq7000 xc7z020clg400
+  Memory: OK
+  Flash: NA
+
+- ID: vcu118
+  Description: Xilinx VCU118
+  URL: https://www.xilinx.com/products/boards-and-kits/vcu118.html
+  FPGA: Virtex UltraScale+ xcvu9pl2flga2104e
   Memory: OK
   Flash: NA

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -204,6 +204,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("papilio_one",     "xc3s500evq100", "papilio", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("usrpx300",        "xc7k325tffg900", "digilent", 0, 0, CABLE_MHZ(15)),
 	JTAG_BOARD("usrpx310",        "xc7k410tffg900", "digilent", 0, 0, CABLE_MHZ(15)),
+	JTAG_BOARD("vcu118",          "xcvu9pl2flga2104e", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT)
 };
 
 #endif

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -64,6 +64,8 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	{0x03727093, {"xilinx", "zynq",     "xc7z020", 6}},
 	{0x23731093, {"xilinx", "zynq",     "xc7z045", 6}},
 
+	{0x04b31093, {"xilinx", "virtexusp", "xcvu9p", 6}},
+
 	/* When powering a zynq ultrascale+ MPSoC, PL Tap and ARM dap
 	 * are disabled and only PS tap with a specific IDCODE is seen.
 	 * 0x03 must be written into JTAG_CTRL followed by RTI and

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -76,6 +76,8 @@ Xilinx::Xilinx(Jtag *jtag, const std::string &filename,
 		_fpga_family = KINTEX_FAMILY;
 	} else if (family == "kintexus") {
 		_fpga_family = KINTEXUS_FAMILY;
+	} else if (family == "virtexusp") {
+		_fpga_family = VIRTEXUSP_FAMILY;
 	} else if (family.substr(0, 8) == "spartan3") {
 		_fpga_family = SPARTAN3_FAMILY;
 		if (_mode != Device::MEM_MODE) {
@@ -454,7 +456,7 @@ void Xilinx::program_mem(ConfigBitstreamParser *bitfile)
 	/*
 	 * 17: Enter the SELECT-IR state.                     X     1   2
 	 * 18: Move to the SHIFT-IR state.                    X     0   2
-	 * 19: Start loading the JSTART instruction 
+	 * 19: Start loading the JSTART instruction
 	 *     (optional). The JSTART instruction           01100   0   5
 	 *     initializes the startup sequence.
 	 * 20: Load the last bit of the JSTART instruction.   0     1   1

--- a/src/xilinx.hpp
+++ b/src/xilinx.hpp
@@ -166,6 +166,7 @@ class Xilinx: public Device, SPIInterface {
 			ZYNQ_FAMILY,
 			ZYNQMP_FAMILY,
 			XCF_FAMILY,
+			VIRTEXUSP_FAMILY,
 			UNKNOWN_FAMILY  = 999
 		};
 


### PR DESCRIPTION
Hey,

Here's a basic support for the Xilinx VCU118 board / Virtex UltraScale+ XCVU9P FPGA.
I could test it locally with a complex design and it works as expected.

The `spiOverJtag` image is missing.
I'll try to add it later in a new PR when I have access to a machine with Vivado and the proper (paid) license.