### PR TITLE
boards: add Sitlinv STLV7325

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -504,6 +504,13 @@
   Memory: OK
   Flash: OK
 
+- ID: stlv7325
+  Description: Sitlinv STLV7325 Board
+  URL: https://www.aliexpress.com/item/1005001275162791.html
+  FPGA: Kintex xc7k325tffg676
+  Memory: OK
+  Flash: OK
+
 - ID: tangnano
   Description: Sipeed Tang Nano
   URL: https://tangnano.sipeed.com/en/

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -176,6 +176,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("genesys2",        "xc7k325tffg900", "digilent_b", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("pynq_z2",         "xc7z020clg400",  "ft2232", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("spec150",         "xc6slx150tfgg484", "", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("stlv7325",        "xc7k325tffg676", "ft4232", 0, 0, CABLE_MHZ(3)),
 	JTAG_BOARD("runber",          "", "ft232",      0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("tangnano",        "", "ch552_jtag", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("tangnano1k",      "", "ft2232",     0, 0, CABLE_DEFAULT),


### PR DESCRIPTION
Sitlinv STLV7325 is a board with XC7K325T-FFG676.

Add support for it.

The board does not have JTAG cables on board, however its vendor provides an option to buy a FT4232-based JTAG cable with the board, so the default cable is set to ft4232.

Signed-off-by: Icenowy Zheng <uwu@icenowy.me>