### PR TITLE
doc/cable: Update libgpiod link

### DIFF
--- a/doc/cable.yml
+++ b/doc/cable.yml
@@ -256,7 +256,7 @@ libgpiod:
 
   - Name: Bitbang GPIO
     Description: Bitbang GPIO pins on Linux host.
-    URL: https://github.com/brgl/libgpiod
+    URL: https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/
 
 jetson-nano-gpio:
 


### PR DESCRIPTION
libgpiod is no longer actively developed on GitHub (the repo is archived). Active development happens on git.kernel.org instead.