### PR TITLE
Fix typo in part name and family.

### DIFF
--- a/src/part.hpp
+++ b/src/part.hpp
@@ -50,7 +50,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	{0x037c4093, {"xilinx", "spartan7", "xc7s25", 6}},
 	{0x0362f093, {"xilinx", "spartan7", "xc7s50", 6}},
 
-	{0x06e5d093, {"xilinx", "xa2c",     "xa2c64a",   8}},
+	{0x06e5d093, {"xilinx", "xc2c",     "xc2c64a",   8}},
 	{0x06e1c093, {"xilinx", "xc2c",     "xc2c32a",   8}},
 	{0x09602093, {"xilinx", "xc9500xl", "xc9536xl",  8}},
 	{0x09604093, {"xilinx", "xc9500xl", "xc9572xl",  8}},


### PR DESCRIPTION
I found wrong information on the web when looking up the part name from the ID code.
Sorry about that.