### PR TITLE
Add initial support for VCU128

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -704,3 +704,10 @@
   FPGA: Virtex UltraScale+ xcvu9p-flga2104
   Memory: OK
   Flash: OK
+
+- ID: vcu128
+  Description: Xilinx VCU128
+  URL: https://www.xilinx.com/products/boards-and-kits/vcu128.html
+  FPGA: Virtex UltraScale+ xcvu37p-fsvh2892
+  Memory: OK
+  Flash: NA

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -204,6 +204,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("usrpx300",        "xc7k325tffg900", "digilent", 0, 0, CABLE_MHZ(15)),
 	JTAG_BOARD("usrpx310",        "xc7k410tffg900", "digilent", 0, 0, CABLE_MHZ(15)),
 	JTAG_BOARD("vcu118",          "xcvu9p-flga2104", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("vcu128",          "xcvu37p-fsvh2892", "ft4232", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("xyloni_jtag",     "", "efinix_jtag_ft4232"       , 0, 0, CABLE_DEFAULT),
 	SPI_BOARD("xyloni_spi",       "efinix", "efinix_spi_ft4232",
 			DBUS4, DBUS5, DBUS7, DBUS3, DBUS0, DBUS1, DBUS2, DBUS6, 0, CABLE_DEFAULT),

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -66,6 +66,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	{0x23731093, {"xilinx", "zynq",     "xc7z045", 6}},
 
 	{0x04b31093, {"xilinx", "virtexusp", "xcvu9p", 18}},
+	{0x14b79093, {"xilinx", "virtexusp", "xcvu37p", 18}},
 
 	/* When powering a zynq ultrascale+ MPSoC, PL Tap and ARM dap
 	 * are disabled and only PS tap with a specific IDCODE is seen.

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -74,7 +74,7 @@ static std::map<std::string, std::map<std::string, std::vector<uint8_t>>>
 		{
 			/* Xilinx Virtex UltraScale+ */
 			/* <vivado_dir>/data/parts/xilinx/virtexuplus/public/bsdl/xcvu9p_flga2104.bsd */
-			"xcvu9p",
+			"virtexusp",
 			{
 				{ "USER1",       {0b00100100, 0b00101001, 0b00} },
 				{ "USER2",       {0b00100100, 0b00111001, 0b00} },
@@ -195,7 +195,7 @@ Xilinx::Xilinx(Jtag *jtag, const std::string &filename,
 		_fpga_family = KINTEXUS_FAMILY;
 	} else if (family == "virtexusp") {
 		_fpga_family = VIRTEXUSP_FAMILY;
-		_ircode_map = ircode_mapping.at(model);
+		_ircode_map = ircode_mapping.at("virtexusp");
 	} else if (family.substr(0, 8) == "spartan3") {
 		_fpga_family = SPARTAN3_FAMILY;
 		if (_mode != Device::MEM_MODE) {


### PR DESCRIPTION
Add bitstream loading to SRAM support for VCU128 board. Most parts are the same as VCU118 except for ftdi chip and IDCODE.