### PR TITLE
add the skip_load_bridge and skip_reset arguments for Xilinx devices

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -540,7 +540,7 @@ int main(int argc, char **argv)
 		if (fab == "xilinx") {
 			fpga = new Xilinx(jtag, args.bit_file, args.secondary_bit_file,
 				args.file_type, args.prg_type, args.fpga_part, args.bridge_path,
-				args.target_flash, args.verify, args.verbose);
+				args.target_flash, args.verify, args.verbose, args.skip_load_bridge, args.skip_reset);
 		} else if (fab == "altera") {
 			fpga = new Altera(jtag, args.bit_file, args.file_type,
 				args.prg_type, args.fpga_part, args.bridge_path, args.verify,

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -128,9 +128,11 @@ Xilinx::Xilinx(Jtag *jtag, const std::string &filename,
 	Device::prog_type_t prg_type,
 	const std::string &device_package, const std::string &spiOverJtagPath,
 	const std::string &target_flash,
-	bool verify, int8_t verbose):
+	bool verify, int8_t verbose,
+	bool skip_load_bridge, bool skip_reset):
 	Device(jtag, filename, file_type, verify, verbose),
-	SPIInterface(filename, verbose, 256, verify),
+	SPIInterface(filename, verbose, 256, verify, skip_load_bridge,
+				 skip_reset),
 	_device_package(device_package), _spiOverJtagPath(spiOverJtagPath),
 	_irlen(6), _filename(filename), _secondary_filename(secondary_filename)
 {
@@ -432,6 +434,24 @@ void Xilinx::program(unsigned int offset, bool unprotect_flash)
 	}
 
 	delete bit;
+}
+
+bool Xilinx::post_flash_access()
+{
+	if (_skip_reset)
+		printInfo("Skip resetting device");
+	else
+		reset();
+	return true;
+}
+
+bool Xilinx::prepare_flash_access()
+{
+	if (_skip_load_bridge) {
+		printInfo("Skip loading bridge for spiOverjtag");
+		return true;
+	}
+	return load_bridge();
 }
 
 bool Xilinx::load_bridge()

--- a/src/xilinx.hpp
+++ b/src/xilinx.hpp
@@ -23,7 +23,8 @@ class Xilinx: public Device, SPIInterface {
 				const std::string &device_package,
 				const std::string &spiOverJtagPath,
 				const std::string &target_flash,
-				bool verify, int8_t verbose);
+				bool verify, int8_t verbose,
+				bool skip_load_bridge, bool skip_reset);
 		~Xilinx();
 
 		void program(unsigned int offset, bool unprotect_flash) override;
@@ -143,11 +144,11 @@ class Xilinx: public Device, SPIInterface {
 		/*!
 		 * \brief prepare SPI flash access (need to have bridge in RAM)
 		 */
-		virtual bool prepare_flash_access() override {return load_bridge();}
+		virtual bool prepare_flash_access() override;
 		/*!
 		 * \brief end of SPI flash access
 		 */
-		virtual bool post_flash_access() override {reset(); return true;}
+		virtual bool post_flash_access() override;
 
 	private:
 		/* list of xilinx family devices */


### PR DESCRIPTION
Hi,
I extended the command line arguments "skip_load_bridge" and "skip_reset"  for Altera devices to be used with Xilinx devices.

Please let me know if there are some modifications necessary.

hycrypt