### PR TITLE
JLINK updates and Efinix JTAG fix

### DIFF
--- a/doc/cable.yml
+++ b/doc/cable.yml
@@ -182,6 +182,12 @@ jlink:
     Description: SEGGER J-Link Debug Probes
     URL: https://www.segger.com/products/debug-probes/j-link
 
+  - Name: jlink_base
+    Description: SEGGER J-Link BASE Debug Probes
+
+  - Name: jtrace_pro
+    Description: SEGGER J-Trace PRO Debug Probes
+
 
 jtag-smt2-nc:
 

--- a/doc/vendors/efinix.rst
+++ b/doc/vendors/efinix.rst
@@ -25,3 +25,27 @@ or, for xyloni board
 
 Since openFPGALoader access the flash directly in SPI mode the ``-b fireant``, ``-b xyloni_spi`` is required (no
 autodetection possible).
+
+Trion and Titanium JTAG usage
+==========================================
+
+*openFPGALoader* supports loading to RAM and SPI Flash with JTAG
+
+Tested with J-Link BASE
+
+bin file load
+-------------
+
+.. code-block:: bash
+
+    openFPGALoader --cable jlink_base -m  /somewhere/project/outflow/*.bin
+
+hex file flash
+-------------
+
+Example for ti60f225.
+NOTE: JTAG chains with more than one device (eg --index-chain) are currently not supported for writing to SPI flash
+
+.. code-block:: bash
+
+    openFPGALoader --cable jlink_base --fpga-part ti60f225 -f  /somewhere/project/outflow/*.hex

--- a/src/cable.hpp
+++ b/src/cable.hpp
@@ -107,6 +107,8 @@ static std::map <std::string, cable_t> cable_list = {
 	{"ft4232",             FTDI_SER(0x0403, 0x6011, FTDI_INTF_A, 0x08, 0x0B, 0x08, 0x0B)},
 	{"ecpix5-debug",       FTDI_SER(0x0403, 0x6010, FTDI_INTF_A, 0xF8, 0xFB, 0xFF, 0xFF)},
 	{"jlink",              CABLE_DEF(MODE_JLINK, 0x1366, 0x0105                        )},
+	{"jlink_base",         CABLE_DEF(MODE_JLINK, 0x1366, 0x0101                        )},
+	{"jtrace_pro",         CABLE_DEF(MODE_JLINK, 0x1366, 0x1020                        )},
 	{"jtag-smt2-nc",       FTDI_SER(0x0403, 0x6014, FTDI_INTF_A, 0xe8, 0xeb, 0x00, 0x60)},
 	{"lpc-link2",          CMSIS_CL(0x1fc9, 0x0090                                     )},
 	{"orbtrace",           CMSIS_CL(0x1209, 0x3443                                     )},

--- a/src/jlink.cpp
+++ b/src/jlink.cpp
@@ -50,8 +50,11 @@ Jlink::Jlink(uint32_t clkHz, int8_t verbose, int vid = VID, int pid = PID):_base
 		throw std::runtime_error("libusb init failed\n");
 
 	// search for all compatible devices
-	if (!jlink_scan_usb(vid,pid))
+	if (!jlink_scan_usb(vid,pid)) {
+		if (_verbose)
+			printf("vid:pid %04x:%04x\n", vid, pid);
 		throw std::runtime_error("can't find compatible device");
+	}
 
 	// get device capacity
 	if (!get_caps())
@@ -680,8 +683,13 @@ bool Jlink::jlink_scan_usb(int vid, int pid)
 			return EXIT_FAILURE;
 		}
 
-		if (desc.idProduct != pid || desc.idVendor != vid)
+		if (desc.idVendor != vid)
 			continue;
+		if (desc.idProduct != pid) {
+			if (_verbose)
+				cerr << "skip pid" << hex << desc.idProduct << dec << endl;
+			continue;
+		}
 
 		if (_verbose)
 			printf("%04x:%04x (bus %d, device %2d)\n",

--- a/src/jlink.cpp
+++ b/src/jlink.cpp
@@ -137,7 +137,10 @@ int Jlink::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 			xfer_len = len - rest;  // reduce xfer len
 		uint16_t tt = (xfer_len + 7) >> 3;  // convert to Byte
 		memset(_tms, tms, tt);  // fill tms buffer
-		memcpy(_tdi, tx_ptr, tt);  // fill tdi buffer
+		if (tx)
+			memcpy(_tdi, tx_ptr, tt);  // fill tdi buffer
+		else
+			memset(_tdi, 0, tt);  // clear tdi buffer
 		_num_bits = xfer_len;  // set buffer size in bit
 		if (end && xfer_len + rest == len) {  // last sequence: set tms 1
 			_last_tms = 1;

--- a/src/jlink.hpp
+++ b/src/jlink.hpp
@@ -118,11 +118,16 @@ class Jlink: public JtagInterface {
 		};
 		
 		// JLink hardware type
-		const std::string jlink_hw_type[4] = {
+		const std::string jlink_hw_type[9] = {
 			"J-Link",
 			"J-Trace",
 			"Flasher",
-			"J-Link Pro"
+			"J-Link Pro",
+			"",
+			"",
+			"",
+			"",
+			"J-Trace Pro"
 		};
 		
 		// Jlink configuration structure


### PR DESCRIPTION
This adds:
* support for more SEGGER devices: J-Link BASE and J-Trace PRO
* JLINK fix when a bug observed when sending bitstreams to Efinix devices
* Efinix fix so JTAG works - tested with J-Link BASE as follows:

% ./openFPGALoader --cable jlink_base --index-chain 0 -m  ./path/to/design.bit