### PR TITLE
Relax ID matching for the misc_dev

### DIFF
--- a/src/jtag.cpp
+++ b/src/jtag.cpp
@@ -200,7 +200,7 @@ int Jtag::detectChain(int max_dev)
 			 * GateMate and Efinix Trion T4/T8 devices
 			 */
 			if (tmp != 0x20000001)
-				found = search_and_insert_device_with_idcode(tmp & 0x0fffffff);
+				found = search_and_insert_device_with_idcode(tmp);
 			if (!found) /* if masked not found -> search for full */
 				found = search_and_insert_device_with_idcode(tmp);
 
@@ -231,7 +231,7 @@ bool Jtag::search_and_insert_device_with_idcode(uint32_t idcode)
 	if (dev != fpga_list.end())
 		irlength = dev->second.irlength;
 	if (irlength == -1) {
-		auto misc = misc_dev_list.find(idcode);
+		auto misc = misc_dev_list.find(idcode & MISC_DEV_MASK);
 		if (misc != misc_dev_list.end())
 			irlength = misc->second.irlength;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -470,11 +470,11 @@ int main(int argc, char **argv)
 				fpga_list[t].family.c_str(),
 				fpga_list[t].model.c_str());
 				printf("\tirlength %d\n", fpga_list[t].irlength);
-			} else if (misc_dev_list.find(t) != misc_dev_list.end()) {
+			} else if (misc_dev_list.find(t & MISC_DEV_MASK) != misc_dev_list.end()) {
 				printf("\tidcode   0x%x\n\ttype     %s\n\tirlength %d\n",
 				t,
-				misc_dev_list[t].name.c_str(),
-				misc_dev_list[t].irlength);
+				misc_dev_list[t & MISC_DEV_MASK].name.c_str(),
+				misc_dev_list[t & MISC_DEV_MASK].irlength);
 			}
 		}
 		if (args.detect == true) {

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -177,10 +177,15 @@ typedef struct {
 	int irlength;
 } misc_device;
 
+/* Maybe a manual list with per device mask is more adequate
+ *
+ * E.g Atmel AVR devices would need a mask 0x0f0003ffU
+ */
+#define MISC_DEV_MASK 0x0ff003ffU
 static std::map <uint32_t, misc_device> misc_dev_list = {
-	{0x4ba00477, {"ARM cortex A9",         4}},
-	{0x5ba00477, {"ARM cortex A53",        4}},
-	{0xfffffffe, {"ZynqMP dummy device",   12}},
+	{0x0ba00077, {"ADIv5 JTAG-DP port",    4}},
+	{0x06400041, {"STM32 Device",          5}},
+	{0x0ff00ffe, {"ZynqMP dummy device",   12}},
 };
 
 /* list of JTAG manufacturer ID */

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -887,7 +887,7 @@ bool Xilinx::flow_program(JedParser *jed)
 	 */
 	size_t nb_section = jed->nb_section() / (15);
 
-	ProgressBar progress("Write Flash", nb_section, 50, _quiet);
+	ProgressBar progress("Write XC95 Flash", nb_section, 50, _quiet);
 
 	for (size_t i = 0; i < nb_section; i++) {
 		uint16_t addr2 = i * 32;
@@ -918,6 +918,7 @@ bool Xilinx::flow_program(JedParser *jed)
 					_jtag->shiftDR(wr_buf, NULL, 8 * (_xc95_line_len + 2));
 					_jtag->toggleClk((_jtag->getClkFreq() * 50) / 1000);
 					_jtag->shiftDR(NULL, rd_buf, 8 * (_xc95_line_len + 2) + 2);
+                                        fprintf(stderr, "xc95 prog: i %ld ii% d loop %d\n", i, ii, loop_try);
 					if ((rd_buf[0] & 0x03) == 0x01)
 						break;
 				}


### PR DESCRIPTION
Detect STM32

Example output:
> ./openFPGALoader -c ftdijtag --detect
Jtag frequency : requested 6.00MHz   -> real 6.00MHz  
index 0:
        idcode   0x6411041
        type     STM32 Device
        irlength 4
index 1:
        idcode   0x4ba00477
        type     ADIv5 JTAG-DP port
        irlength 4
