### PR TITLE
WIP: Do not compare verbosity level when passing value along.

### DIFF
--- a/src/ftdipp_mpsse.cpp
+++ b/src/ftdipp_mpsse.cpp
@@ -28,7 +28,7 @@ using namespace std;
 
 FTDIpp_MPSSE::FTDIpp_MPSSE(const cable_t &cable, const string &dev,
 				const std::string &serial, uint32_t clkHZ, int8_t verbose):
-				_verbose(verbose > 2), _cable(cable.config), _vid(0),
+				_verbose(verbose), _cable(cable.config), _vid(0),
 				_pid(0), _index(0),
 				_bus(cable.bus_addr), _addr(cable.device_addr),
 				_bitmode(BITMODE_RESET),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -256,7 +256,7 @@ int main(int argc, char **argv)
 			pins_config = board->spi_pins_config;
 
 		try {
-			spi = new FtdiSpi(cable, pins_config, args.freq, args.verbose > 0);
+			spi = new FtdiSpi(cable, pins_config, args.freq, args.verbose);
 		} catch (std::exception &e) {
 			printError("Error: Failed to claim cable");
 			return EXIT_FAILURE;


### PR DESCRIPTION
I was not able to see the `display()` message `FTDIpp_MPSSE::open_device` (`src/ftdipp_mpsse.cpp`), even with e.g. `--verbose-level 4`.  As far as I could tell, this is due to the user-given verbosity level being compared with fixed levels several times as it is passed to the `FTDIpp_MPSSE` constructor.

It is unclear why I had to remove both comparisons to see the `display()` message.  So the PR is more to easily point at the locations in the code, and not for direct use.  It is not much tested.