### PR TITLE
Parse USB bus:dev as decimal integers, to be consistent with `--scan-usb`.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -895,9 +895,9 @@ int parse_opt(int argc, char **argv, struct arguments *args,
 			}
 			try {
 				args->bus_addr = static_cast<uint8_t>(std::stoi(bus_dev_num[0],
-					nullptr, 16));
+					nullptr, 10));
 				args->device_addr = static_cast<uint8_t>(
-					std::stoi(bus_dev_num[1], nullptr, 16));
+					std::stoi(bus_dev_num[1], nullptr, 10));
 			} catch (std::exception &e) {
 				printError("Error: busdev-num invalid format: must be numeric values");
 				throw std::exception();


### PR DESCRIPTION
Do not accept auto-detected base 0 (e.g. prefix '0x' for hex), since '0' prefix gives an octal interpretation, and the user is likely to copy values from `--scan-usb` or `lsusb` that could then be misinterpreted, e.g. 005:010.

See description in #354.