### PR TITLE
part/board: adding Avnet Mini-ITX

### DIFF
--- a/src/board.hpp
+++ b/src/board.hpp
@@ -222,7 +222,8 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("kcu116",          "xcku5p-ffvb676", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("zedboard",        "xc7z020clg484", "digilent_hs2", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("zybo_z7_10",      "xc7z010clg400",  "digilent", 0, 0, CABLE_DEFAULT),
-	JTAG_BOARD("zybo_z7_20",      "xc7z020clg400",  "digilent", 0, 0, CABLE_DEFAULT)
+	JTAG_BOARD("zybo_z7_20",      "xc7z020clg400",  "digilent", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("mini_itx",        "xc7z100ffg900", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT)
 };
 
 #endif

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -82,6 +82,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	{0x03722093, {"xilinx", "zynq",     "xc7z010", 6}},
 	{0x03727093, {"xilinx", "zynq",     "xc7z020", 6}},
 	{0x23731093, {"xilinx", "zynq",     "xc7z045", 6}},
+	{0x03736093, {"xilinx", "zynq",     "xc7z100", 6}},
 
 	/* Xilinx Ultrascale / Kintex */
 	{0x13822093, {"xilinx", "kintexus", "xcku040", 6}},


### PR DESCRIPTION
Adding the Avnet Mini-ITX dev board that uses the XC7Z100 Zynq-7000 device.