### PR TITLE
Generic refactoring of the code

### DIFF
--- a/src/altera.cpp
+++ b/src/altera.cpp
@@ -78,7 +78,7 @@ void Altera::reset()
 void Altera::programMem(RawParser &_bit)
 {
 	int byte_length = _bit.getLength()/8;
-	uint8_t *data = _bit.getData();
+	const uint8_t *data = _bit.getData();
 
 	uint32_t clk_period = 1e9/static_cast<float>(_jtag->getClkFreq());
 
@@ -232,7 +232,7 @@ void Altera::program(unsigned int offset, bool unprotect_flash)
 			reverseOrder = true;
 
 		/* prepare data to write */
-		uint8_t *data = NULL;
+		const uint8_t *data = NULL;
 		int length = 0;
 
 		RawParser bit(_filename, reverseOrder);
@@ -266,7 +266,7 @@ int Altera::idCode()
 
 /* SPI interface */
 
-int Altera::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
+int Altera::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	/* +1 because send first cmd + len byte + 1 for rx due to a delay of
 	 * one bit
@@ -291,7 +291,7 @@ int Altera::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
 
 	return 0;
 }
-int Altera::spi_put(uint8_t *tx, uint8_t *rx, uint32_t len)
+int Altera::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	return spi_put(tx[0], &tx[1], rx, len-1);
 }

--- a/src/altera.cpp
+++ b/src/altera.cpp
@@ -250,7 +250,7 @@ void Altera::program(unsigned int offset, bool unprotect_flash)
 	}
 }
 
-int Altera::idCode()
+uint32_t Altera::idCode()
 {
 	unsigned char tx_data[4] = {IDCODE};
 	unsigned char rx_data[4];

--- a/src/altera.cpp
+++ b/src/altera.cpp
@@ -101,7 +101,7 @@ void Altera::programMem(RawParser &_bit)
 
 	int xfer_len = 512;
 	int tx_len;
-	int tx_end;
+	Jtag::tapState_t tx_end;
 
 	for (int i=0; i < byte_length; i+=xfer_len) {
 		if (i + xfer_len > byte_length) {  // last packet with some size
@@ -352,7 +352,7 @@ void Altera::shiftVIR(uint32_t reg)
 }
 
 void Altera::shiftVDR(uint8_t * tx, uint8_t * rx, uint32_t len,
-		int end_state, bool debug)
+		Jtag::tapState_t end_state, bool debug)
 {
 	(void) debug;
 	uint8_t tx_ir[2] = {USER0, 0};

--- a/src/altera.hpp
+++ b/src/altera.hpp
@@ -65,9 +65,9 @@ class Altera: public Device, SPIInterface {
 			return SPIInterface::bulk_erase_flash();
 		}
 
-		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
+		int spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 				uint32_t len) override;
-		int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) override;
+		int spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len) override;
 		int spi_wait(uint8_t cmd, uint8_t mask, uint8_t cond,
 				uint32_t timeout, bool verbose = false) override;
 

--- a/src/altera.hpp
+++ b/src/altera.hpp
@@ -39,7 +39,7 @@ class Altera: public Device, SPIInterface {
 			return SPIInterface::dump(base_addr, len);
 		}
 
-		int idCode() override;
+		uint32_t idCode() override;
 		void reset() override;
 
 		/*************************/

--- a/src/altera.hpp
+++ b/src/altera.hpp
@@ -98,7 +98,7 @@ class Altera: public Device, SPIInterface {
 		 * \param[in] end_state: next state at the end of xfer
 		 */
 		void shiftVDR(uint8_t * tx, uint8_t * rx, uint32_t len,
-				int end_state = Jtag::UPDATE_DR, bool debug = false);
+				Jtag::tapState_t end_state = Jtag::UPDATE_DR, bool debug = false);
 
 		std::string _device_package;
 		std::string _spiOverJtagPath; /**< spiOverJtag explicit path */

--- a/src/anlogic.cpp
+++ b/src/anlogic.cpp
@@ -77,7 +77,7 @@ void Anlogic::program(unsigned int offset, bool unprotect_flash)
 	if (_verbose)
 		bit.displayHeader();
 
-	uint8_t *data = bit.getData();
+	const uint8_t *data = bit.getData();
 	int len = bit.getLength() / 8;
 
 	if (_mode == Device::SPI_MODE) {
@@ -110,7 +110,7 @@ void Anlogic::program(unsigned int offset, bool unprotect_flash)
 
 		ProgressBar progress("Loading", len, 50, _quiet);
 		int pos = 0;
-		uint8_t *ptr = data;
+		const uint8_t *ptr = data;
 		while (len > 0) {
 			int xfer_len = (len > 512)?512:len;
 			int tx_end;
@@ -184,7 +184,7 @@ bool Anlogic::prepare_flash_access()
  * In write only operations to care about this delay
  */
 
-int Anlogic::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
+int Anlogic::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int xfer_len = len + 1;
 	if (rx)
@@ -210,7 +210,7 @@ int Anlogic::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
 	}
 	return 0;
 }
-int Anlogic::spi_put(uint8_t *tx, uint8_t *rx, uint32_t len)
+int Anlogic::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int xfer_len = len;
 	if (rx)

--- a/src/anlogic.cpp
+++ b/src/anlogic.cpp
@@ -113,11 +113,7 @@ void Anlogic::program(unsigned int offset, bool unprotect_flash)
 		const uint8_t *ptr = data;
 		while (len > 0) {
 			int xfer_len = (len > 512)?512:len;
-			Jtag::tapState_t tx_end;
-			if (len - xfer_len == 0)
-				tx_end = Jtag::RUN_TEST_IDLE;
-			else
-				tx_end = Jtag::SHIFT_DR;
+			Jtag::tapState_t tx_end = (len - xfer_len) ? Jtag::SHIFT_DR : Jtag::RUN_TEST_IDLE;
 			_jtag->shiftDR(ptr, NULL, xfer_len * 8, tx_end);
 			len -= xfer_len;
 			progress.display(pos);
@@ -143,7 +139,7 @@ void Anlogic::program(unsigned int offset, bool unprotect_flash)
 	}
 }
 
-int Anlogic::idCode()
+uint32_t Anlogic::idCode()
 {
 	unsigned char tx_data[4];
 	unsigned char rx_data[4];

--- a/src/anlogic.cpp
+++ b/src/anlogic.cpp
@@ -113,7 +113,7 @@ void Anlogic::program(unsigned int offset, bool unprotect_flash)
 		const uint8_t *ptr = data;
 		while (len > 0) {
 			int xfer_len = (len > 512)?512:len;
-			int tx_end;
+			Jtag::tapState_t tx_end;
 			if (len - xfer_len == 0)
 				tx_end = Jtag::RUN_TEST_IDLE;
 			else

--- a/src/anlogic.hpp
+++ b/src/anlogic.hpp
@@ -22,7 +22,7 @@ class Anlogic: public Device, SPIInterface {
 		~Anlogic();
 
 		void program(unsigned int offset, bool unprotect_flash) override;
-		int idCode() override;
+		uint32_t idCode() override;
 		void reset() override;
 
 		/* spi interface */

--- a/src/anlogic.hpp
+++ b/src/anlogic.hpp
@@ -57,9 +57,9 @@ class Anlogic: public Device, SPIInterface {
 			return SPIInterface::dump(base_addr, len);
 		}
 
-		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
+		int spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 			uint32_t len) override;
-		int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) override;
+		int spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len) override;
 		int spi_wait(uint8_t cmd, uint8_t mask, uint8_t cond,
 			uint32_t timeout, bool verbose=false) override;
 

--- a/src/anlogicBitParser.cpp
+++ b/src/anlogicBitParser.cpp
@@ -109,9 +109,9 @@ int AnlogicBitParser::parse()
 	for (auto it = blocks.begin(); it != blocks.end(); it++) {
 		for (size_t xpos = 0; xpos < it->size(); xpos++) {
 			if (_reverseOrder == true)
-				_bit_data += reverseByte(((*it)[xpos]));
+				_bit_data.push_back(reverseByte(((*it)[xpos])));
 			else
-				_bit_data += ((*it)[xpos]);
+				_bit_data.push_back((*it)[xpos]);
 		}
 	}
 	_bit_length = _bit_data.size() * 8;

--- a/src/anlogicCable.cpp
+++ b/src/anlogicCable.cpp
@@ -123,7 +123,7 @@ int AnlogicCable::setClkFreq(uint32_t clkHZ)
 	}
 
 	ret = libusb_bulk_transfer(dev_handle, ANLOGICCABLE_CONF_EP,
-			        buf, 2, &actual_length, 1000);
+					buf, 2, &actual_length, 1000);
 	if (ret < 0) {
 		cerr << "setClkFreq: usb bulk write failed " << ret << endl;
 		return -EXIT_FAILURE;
@@ -137,7 +137,7 @@ int AnlogicCable::setClkFreq(uint32_t clkHZ)
 	return clkHZ;
 }
 
-int AnlogicCable::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
+int AnlogicCable::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer)
 {
 	(void) flush_buffer;
 
@@ -148,7 +148,7 @@ int AnlogicCable::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
 	uint8_t mask = (ANLOGICCABLE_TCK_PIN << 4);
 
 	int full_len = len;
-	uint8_t *tx_ptr = tms;
+	const uint8_t *tx_ptr = tms;
 
 	while (full_len > 0) {
 		/* when len > buffer capacity -> limit to capacity
@@ -219,13 +219,13 @@ int AnlogicCable::flush()
 	return 0;
 }
 
-int AnlogicCable::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
+int AnlogicCable::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 {
 	uint8_t buf[512];
 	uint8_t mask = (ANLOGICCABLE_TCK_PIN << 4);
 
 	int full_len = len;
-	uint8_t *tx_ptr = tx;
+	const uint8_t *tx_ptr = tx;
 	uint8_t *rx_ptr = rx;
 
 	while (full_len > 0) {

--- a/src/anlogicCable.hpp
+++ b/src/anlogicCable.hpp
@@ -25,9 +25,9 @@ class AnlogicCable : public JtagInterface {
 	int setClkFreq(uint32_t clkHZ) override;
 
 	/* TMS */
-	int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) override;
+	int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) override;
 	/* TDI */
-	int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+	int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 	/* clk */
 	int toggleClk(uint8_t tms, uint8_t tdi, uint32_t clk_len) override;
 
@@ -45,7 +45,7 @@ class AnlogicCable : public JtagInterface {
  private:
 	int write(uint8_t *in_buf, uint8_t *out_buf, int len, int rd_len);
 
-    libusb_device_handle *dev_handle;
+	libusb_device_handle *dev_handle;
 	libusb_context *usb_ctx;
 };
 #endif  // SRC_ANLOGICCABLE_HPP_

--- a/src/ch347jtag.cpp
+++ b/src/ch347jtag.cpp
@@ -193,7 +193,7 @@ CH347Jtag::CH347Jtag(uint32_t clkHZ, int8_t verbose):
 	}
 	libusb_bulk_transfer(dev_handle, CH347JTAG_READ_EP, ibuf, 512,
 		&actual_length, CH347JTAG_TIMEOUT);
-	setClkFreq(clkHZ);
+	_setClkFreq(clkHZ);
 	return;
 usb_release:
 	libusb_release_interface(dev_handle, CH347JTAG_INTF);
@@ -221,7 +221,7 @@ CH347Jtag::~CH347Jtag()
 	}
 }
 
-int CH347Jtag::setClkFreq(uint32_t clkHZ)
+int CH347Jtag::_setClkFreq(uint32_t clkHZ)
 {
 	unsigned i = 0, sl = 2000000;
 	if (clkHZ <= 2000000) {
@@ -244,7 +244,7 @@ int CH347Jtag::setClkFreq(uint32_t clkHZ)
 	return _clkHZ;
 }
 
-int CH347Jtag::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
+int CH347Jtag::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer)
 {
 	(void) flush_buffer;
 
@@ -307,15 +307,15 @@ int CH347Jtag::toggleClk(uint8_t tms, uint8_t tdi, uint32_t len)
 	return EXIT_SUCCESS;
 }
 
-int CH347Jtag::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
+int CH347Jtag::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 {
 	if (!tx || !len)
 		return 0;
 	unsigned bytes = (len - ((end)?1:0)) / 8;
 	unsigned bits = len - bytes * 8;
 	uint8_t *rptr = rx;
-	uint8_t *tptr = tx;
-	uint8_t *txend = &tx[bytes];
+	const uint8_t *tptr = tx;
+	const uint8_t *txend = tx + bytes;
 	uint8_t cmd = (rx) ? CMD_BYTES_WR : CMD_BYTES_WO;
 	while (tptr < txend) {
 		unsigned avail = sizeof(obuf) - 3;
@@ -349,7 +349,7 @@ int CH347Jtag::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 	cmd = (rx) ? CMD_BITS_WR : CMD_BITS_WO;
 	uint8_t *ptr = &obuf[3];
 	uint8_t x = 0;
-	uint8_t *bptr = &tx[bytes];
+	const uint8_t *bptr = &tx[bytes];
 	for (unsigned i = 0; i < bits; ++i) {
 		uint8_t txb = bptr[i >> 3];
 		uint8_t _tdi = (txb & (1 << (i & 7))) ? SIG_TDI : 0;

--- a/src/ch347jtag.hpp
+++ b/src/ch347jtag.hpp
@@ -13,12 +13,12 @@ class CH347Jtag : public JtagInterface {
 	CH347Jtag(uint32_t clkHZ, int8_t verbose);
 	virtual ~CH347Jtag();
 
-	int setClkFreq(uint32_t clkHZ) override;
-
+	int setClkFreq(uint32_t clkHZ) override { return _setClkFreq(clkHZ); };
+	int _setClkFreq(uint32_t clkHZ);
 	/* TMS */
-	int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) override;
+	int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) override;
 	/* TDI */
-	int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+	int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 	/* clk */
 	int toggleClk(uint8_t tms, uint8_t tdo, uint32_t clk_len) override;
 

--- a/src/ch552_jtag.cpp
+++ b/src/ch552_jtag.cpp
@@ -88,7 +88,7 @@ int CH552_jtag::setClkFreq(uint32_t clkHZ) {
 	return ret;
 }
 
-int CH552_jtag::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
+int CH552_jtag::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer)
 {
 	(void) flush_buffer;
 	display("%s %d %d\n", __func__, len, (len/8)+1);
@@ -172,7 +172,7 @@ int CH552_jtag::flush()
 	return ret;
 }
 
-int CH552_jtag::writeTDI(uint8_t *tdi, uint8_t *tdo, uint32_t len, bool last)
+int CH552_jtag::writeTDI(const uint8_t *tdi, uint8_t *tdo, uint32_t len, bool last)
 {
 	bool rd_mode = (tdo) ? true : false;
 	/* 3 possible case :

--- a/src/ch552_jtag.hpp
+++ b/src/ch552_jtag.hpp
@@ -32,11 +32,11 @@ class CH552_jtag : public JtagInterface, private FTDIpp_MPSSE {
 	uint32_t getClkFreq() override {return FTDIpp_MPSSE::getClkFreq();}
 
 	/* TMS */
-	int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) override;
+	int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) override;
 	/* clock */
 	int toggleClk(uint8_t tms, uint8_t tdi, uint32_t clk_len) override;
 	/* TDI */
-	int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+	int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 
 	/*!
 	 * \brief return internal buffer size (in byte).

--- a/src/cmsisDAP.cpp
+++ b/src/cmsisDAP.cpp
@@ -49,11 +49,11 @@ enum cmsisdap_info_id {
 	INFO_ID_PID                = 0x02,  // Get the Product ID (string).
 	INFO_ID_SERNUM             = 0x03,  // Get the Serial Number (string).
 	INFO_ID_FWVERS             = 0x04,  // Get the CMSIS-DAP Firmware
-							     	    // Version (string).
+								 		// Version (string).
 	INFO_ID_TARGET_DEV_VENDOR  = 0x05,  // Get the Target Device Vendor (string).
 	INFO_ID_TARGET_DEV_NAME    = 0x06,  // Get the Target Device Name (string).
 	INFO_ID_HWCAP              = 0xF0,  // Get information about the
-							     	    // Capabilities (BYTE) of the Debug Unit
+								 		// Capabilities (BYTE) of the Debug Unit
 	INFO_ID_SWO_TEST_TIM_PARAM = 0xF1,  // Get the Test Domain Timer parameter
 	INFO_ID_SWO_TRACE_BUF_SIZE = 0xFD,  // Get the SWO Trace Buffer Size (WORD).
 	INFO_ID_MAX_PKT_CNT        = 0xFE,  // Get the maximum Packet Count (BYTE).
@@ -186,23 +186,23 @@ CmsisDAP::CmsisDAP(const cable_t &cable, int index, int8_t verbose):_verbose(ver
 	 * 0 -> info
 	 * 1 -> len (1: info0, 2: info0, info1)
 	 * Available transfer protocols to target:
-    	Info0 - Bit 0: 1 = SWD Serial Wire Debug communication is implemented
-                       0 = SWD Commands not implemented
-        Info0 - Bit 1: 1 = JTAG communication is implemented
-                       0 = JTAG Commands not implemented
-       Serial Wire Trace (SWO) support:
-        Info0 - Bit 2: 1 = SWO UART - UART Serial Wire Output is implemented
-                       0 = not implemented
-        Info0 - Bit 3: 1 = SWO Manchester - Manchester Serial Wire Output is implemented
-                       0 = not implemented
-       Command extensions for transfer protocol:
-        Info0 - Bit 4: 1 = Atomic Commands - Atomic Commands support is implemented
-                       0 = Atomic Commands not implemented
-       Time synchronisation via Test Domain Timer:
-        Info0 - Bit 5: 1 = Test Domain Timer - debug unit support for Test Domain Timer is implemented
-                       0 = not implemented
-       SWO Streaming Trace support:
-        Info0 - Bit 6: 1 = SWO Streaming Trace is implemented (0 = not implemented).
+		Info0 - Bit 0: 1 = SWD Serial Wire Debug communication is implemented
+					   0 = SWD Commands not implemented
+		Info0 - Bit 1: 1 = JTAG communication is implemented
+					   0 = JTAG Commands not implemented
+	   Serial Wire Trace (SWO) support:
+		Info0 - Bit 2: 1 = SWO UART - UART Serial Wire Output is implemented
+					   0 = not implemented
+		Info0 - Bit 3: 1 = SWO Manchester - Manchester Serial Wire Output is implemented
+					   0 = not implemented
+	   Command extensions for transfer protocol:
+		Info0 - Bit 4: 1 = Atomic Commands - Atomic Commands support is implemented
+					   0 = Atomic Commands not implemented
+	   Time synchronisation via Test Domain Timer:
+		Info0 - Bit 5: 1 = Test Domain Timer - debug unit support for Test Domain Timer is implemented
+					   0 = not implemented
+	   SWO Streaming Trace support:
+		Info0 - Bit 6: 1 = SWO Streaming Trace is implemented (0 = not implemented).
 	*/
 	memset(_buffer, 0, 63);
 	int res = read_info(INFO_ID_HWCAP, _buffer, 63);
@@ -313,7 +313,7 @@ int CmsisDAP::setClkFreq(uint32_t clkHZ)
  * flush the buffer
  * tms states are written only if max or if flush_buffer set
  */
-int CmsisDAP::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
+int CmsisDAP::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer)
 {
 	/* nothing to send
 	 * check if the buffer must be flushed
@@ -349,14 +349,15 @@ int CmsisDAP::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
 
 /* 0x14 + number of sequence + seq1 details + tdi + seq2 details + tdi + ...
  */
-int CmsisDAP::writeJtagSequence(uint8_t tms, uint8_t *tx, uint8_t *rx,
+int CmsisDAP::writeJtagSequence(uint8_t tms, const uint8_t *tx, uint8_t *rx,
 		uint32_t len, bool end)
 {
 	int ret;
 	int real_len = len - (end ? 1 : 0);  // full xfer size according to end
-	uint8_t *rx_ptr = rx, *tx_ptr = tx;  // rd & wr ptr
+	uint8_t *rx_ptr = rx;
+	const uint8_t *tx_ptr = tx;  // rd & wr ptr
 	int xfer_byte_len, xfer_bit_len;  // size of one sequence
-                                              // in byte and bit
+											  // in byte and bit
 	int byte_to_read = 0;  // for rd operation number of read in one xfer
 	/* constant part of all sequences info byte */
 	uint8_t seq_info_base = ((rx) ? DAP_JTAG_SEQ_TDO_CAPTURE : 0) |
@@ -462,7 +463,7 @@ int CmsisDAP::writeJtagSequence(uint8_t tms, uint8_t *tx, uint8_t *rx,
 /* send TDI by filling jtag sequence
  * tx buffer is considered to be correctly aligned (LSB first)
  */
-int CmsisDAP::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
+int CmsisDAP::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 {
 	return writeJtagSequence(0, tx, rx, len, end);
 }

--- a/src/cmsisDAP.hpp
+++ b/src/cmsisDAP.hpp
@@ -44,7 +44,7 @@ class CmsisDAP: public JtagInterface {
 		 * \param[in] flush_buffer: force buffer to be send or not
 		 * \return <= 0 if something wrong, len otherwise
 		 */
-		int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) override;
+		int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) override;
 
 		/*!
 		 * \brief write and read len bits with optional tms set to 1 if end
@@ -54,7 +54,7 @@ class CmsisDAP: public JtagInterface {
 		 * \param[in] end: if true tms is set to one with the last tdi bit
 		 * \return <= 0 if something wrong, len otherwise
 		 */
-		int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+		int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 
 		/*!
 		 * \brief send a serie of clock cycle with constant TMS and TDI
@@ -95,7 +95,7 @@ class CmsisDAP: public JtagInterface {
 				uint8_t *rx_buff, int rx_len);
 
 		void display_info(uint8_t info, uint8_t type);
-		int writeJtagSequence(uint8_t tms, uint8_t *tx, uint8_t *rx,
+		int writeJtagSequence(uint8_t tms, const uint8_t *tx, uint8_t *rx,
 				uint32_t len, bool end);
 
 		bool _verbose;                /**< display more message */

--- a/src/colognechip.cpp
+++ b/src/colognechip.cpp
@@ -187,7 +187,7 @@ void CologneChip::program(unsigned int offset, bool unprotect_flash)
 
 	cfg->parse();
 
-	uint8_t *data = cfg->getData();
+	const uint8_t *data = cfg->getData();
 	int length = cfg->getLength() / 8;
 
 	switch (_mode) {
@@ -214,7 +214,7 @@ void CologneChip::program(unsigned int offset, bool unprotect_flash)
  * Write configuration into FPGA latches via SPI after active reset.
  * CFG_MD[3:0] must be set to 0x40 (SPI passive).
  */
-void CologneChip::programSPI_sram(uint8_t *data, int length)
+void CologneChip::programSPI_sram(const uint8_t *data, int length)
 {
 	/* hold device in reset for a moment */
 	reset();
@@ -234,7 +234,7 @@ void CologneChip::programSPI_sram(uint8_t *data, int length)
  * done, release reset to start FPGA in active SPI mode (load from flash).
  * CFG_MD[3:0] must be set to 0x00 (SPI active).
  */
-void CologneChip::programSPI_flash(unsigned int offset, uint8_t *data,
+void CologneChip::programSPI_flash(unsigned int offset, const uint8_t *data,
 		int length, bool unprotect_flash)
 {
 	/* hold device in reset during flash write access */
@@ -266,7 +266,7 @@ void CologneChip::programSPI_flash(unsigned int offset, uint8_t *data,
  * Write configuration into FPGA latches via JTAG after active reset.
  * CFG_MD[3:0] must be set to 0xF0 (JTAG).
  */
-void CologneChip::programJTAG_sram(uint8_t *data, int length)
+void CologneChip::programJTAG_sram(const uint8_t *data, int length)
 {
 	/* hold device in reset for a moment */
 	reset();
@@ -303,7 +303,7 @@ void CologneChip::programJTAG_sram(uint8_t *data, int length)
  * Write configuration to flash via JTAG-SPI-bypass. The FPGA will not start
  * as it is in JTAG mode with CFG_MD[3:0] set to 0xF0 (JTAG).
  */
-void CologneChip::programJTAG_flash(unsigned int offset, uint8_t *data,
+void CologneChip::programJTAG_flash(unsigned int offset, const uint8_t *data,
 		int length, bool unprotect_flash)
 {
 	/* hold device in reset for a moment */
@@ -327,7 +327,7 @@ void CologneChip::programJTAG_flash(unsigned int offset, uint8_t *data,
 /**
  * Overrides spi_put() to access SPI components via JTAG-SPI-bypass.
  */
-int CologneChip::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
+int CologneChip::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int xfer_len = len + 1;
 	uint8_t jtx[xfer_len+2];
@@ -358,7 +358,7 @@ int CologneChip::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
 /**
  * Overrides spi_put() to access SPI components via JTAG-SPI-bypass.
  */
-int CologneChip::spi_put(uint8_t *tx, uint8_t *rx, uint32_t len)
+int CologneChip::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int xfer_len = len;
 	uint8_t jtx[xfer_len+2];

--- a/src/colognechip.hpp
+++ b/src/colognechip.hpp
@@ -48,17 +48,17 @@ class CologneChip: public Device, SPIInterface {
 		void reset() override;
 
 	private:
-		void programSPI_sram(uint8_t *data, int length);
-		void programSPI_flash(unsigned int offset, uint8_t *data, int length,
+		void programSPI_sram(const uint8_t *data, int length);
+		void programSPI_flash(unsigned int offset, const uint8_t *data, int length,
 				bool unprotect_flash);
-		void programJTAG_sram(uint8_t *data, int length);
-		void programJTAG_flash(unsigned int offset, uint8_t *data, int length,
+		void programJTAG_sram(const uint8_t *data, int length);
+		void programJTAG_flash(unsigned int offset, const uint8_t *data, int length,
 				bool unprotect_flash);
 
 		/* spi interface via jtag */
-		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
+		int spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 					uint32_t len) override;
-		int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) override;
+		int spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len) override;
 		int spi_wait(uint8_t cmd, uint8_t mask, uint8_t cond, uint32_t timeout,
 					 bool verbose=false) override;
 

--- a/src/colognechip.hpp
+++ b/src/colognechip.hpp
@@ -44,7 +44,7 @@ class CologneChip: public Device, SPIInterface {
 			printError("bulk erase flash not supported"); return false;}
 		void program(unsigned int offset, bool unprotect_flash) override;
 
-		int idCode() override {return 0;}
+		uint32_t idCode() override {return 0;}
 		void reset() override;
 
 	private:

--- a/src/colognechipCfgParser.cpp
+++ b/src/colognechipCfgParser.cpp
@@ -22,7 +22,7 @@ int CologneChipCfgParser::parse()
 		std::string val = buffer.substr(0, buffer.find("//"));
 		val.erase(std::remove_if(val.begin(), val.end(), ::isspace), val.end());
 		if (val != "") {
-			_bit_data += std::stol(val, nullptr, 16);
+			_bit_data.push_back(std::stol(val, nullptr, 16));
 		}
 	}
 	_bit_length = _bit_data.size() * 8;

--- a/src/configBitstreamParser.hpp
+++ b/src/configBitstreamParser.hpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <vector>
 #include <map>
 
 class ConfigBitstreamParser {
@@ -19,7 +20,7 @@ class ConfigBitstreamParser {
 			bool verbose = false);
 		virtual ~ConfigBitstreamParser();
 		virtual int parse() = 0;
-		uint8_t *getData() {return (uint8_t*)_bit_data.c_str();}
+		const uint8_t *getData() const {return _bit_data.data();}
 		int getLength() {return _bit_length;}
 
 		/**
@@ -62,7 +63,7 @@ class ConfigBitstreamParser {
 		int _bit_length;
 		int _file_size;
 		bool _verbose;
-		std::string _bit_data;
+		std::vector<uint8_t> _bit_data;
 		std::string _raw_data; /**< unprocessed file content */
 		std::map<std::string, std::string> _hdr;
 };

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -50,7 +50,7 @@ class Device {
 		virtual bool unprotect_flash() = 0;
 		virtual bool bulk_erase_flash() = 0;
 
-		virtual int  idCode() = 0;
+		virtual uint32_t idCode() = 0;
 		virtual void reset();
 
 		virtual bool connectJtagToMCU() {return false;}

--- a/src/dfu.cpp
+++ b/src/dfu.cpp
@@ -312,8 +312,8 @@ int DFU::searchDFUDevices()
 
 		if (_verbose > 0) {
 			printf("%04x:%04x (bus %d, device %2d)\n",
-            	desc.idVendor, desc.idProduct,
-            	libusb_get_bus_number(usb_dev),
+				desc.idVendor, desc.idProduct,
+				libusb_get_bus_number(usb_dev),
 				libusb_get_device_address(usb_dev));
 		}
 
@@ -435,12 +435,12 @@ int DFU::parseDFUDescriptor(const struct libusb_interface_descriptor *intf,
 
 /* abstraction to send/receive to control */
 int DFU::send(bool out, uint8_t brequest, uint16_t wvalue,
-		unsigned char *data, uint16_t length)
+		const uint8_t *data, uint16_t length)
 {
 	uint8_t type = out ? DFU_REQUEST_OUT : DFU_REQUEST_IN;
 	int ret = libusb_control_transfer(dev_handle, type,
 				brequest, wvalue, curr_intf,
-				data, length, 5000);
+				const_cast<uint8_t *>(data), length, 5000);
 	if (ret < 0) {
 		if (checkDevicePresent()) {
 			/* close device ? */
@@ -624,8 +624,8 @@ void DFU::displayDFU()
 	printf("Found DFU:\n");
 	for (unsigned int i = 0; i < dfu_dev.size(); i++) {
 		printf("%04x:%04x (bus %d, device %2d),",
-            dfu_dev[i].vid, dfu_dev[i].pid,
-            dfu_dev[i].bus, dfu_dev[i].device);
+			dfu_dev[i].vid, dfu_dev[i].pid,
+			dfu_dev[i].bus, dfu_dev[i].device);
 		printf(" path: %d",dfu_dev[i].path[0]);
 		for (size_t j = 1; j < strlen(((const char *)dfu_dev[i].path)); j++)
 			printf(".%d", dfu_dev[i].path[j]);
@@ -690,7 +690,7 @@ int DFU::download()
 	}
 
 	int ret, ret_val = EXIT_SUCCESS;
-	uint8_t *buffer, *ptr;
+	const uint8_t *buffer, *ptr;
 	int size, xfer_len;
 	int bMaxPacketSize0 = dfu_dev[dev_idx].bMaxPacketSize0;
 

--- a/src/dfu.hpp
+++ b/src/dfu.hpp
@@ -52,12 +52,12 @@ class DFU {
 		 * \brief dfu descriptor structure (not provided by libusb
 		 */
 		struct dfu_desc {
-		    uint8_t  bLength;
-		    uint8_t  bDescriptorType;
-		    uint8_t  bmAttributes;
-		    uint16_t wDetachTimeOut;
-		    uint16_t wTransferSize;
-		    uint16_t bcdDFUVersion;
+			uint8_t  bLength;
+			uint8_t  bDescriptorType;
+			uint8_t  bmAttributes;
+			uint16_t wDetachTimeOut;
+			uint16_t wTransferSize;
+			uint16_t bcdDFUVersion;
 		} __attribute__((__packed__));
 
 		struct dfu_dev {
@@ -200,7 +200,7 @@ class DFU {
 		 * \brief send an IN/OUT request
 		 */
 		int send(bool out, uint8_t brequest, uint16_t wvalue,
-				unsigned char *data, uint16_t length);
+				const uint8_t *data, uint16_t length);
 		/*!
 		 * \brief fill specific DFU structure with extra descriptor
 		 * \param[in] intf: interface descriptor with extra area

--- a/src/dirtyJtag.cpp
+++ b/src/dirtyJtag.cpp
@@ -113,7 +113,7 @@ bool DirtyJtag::getVersion()
 					CMD_STOP};
 	uint8_t rx_buf[64];
 	ret = libusb_bulk_transfer(dev_handle, DIRTYJTAG_WRITE_EP,
-			        buf, 2, &actual_length, DIRTYJTAG_TIMEOUT);
+					buf, 2, &actual_length, DIRTYJTAG_TIMEOUT);
 	if (ret < 0) {
 		cerr << "getVersion: usb bulk write failed " << ret << endl;
 		return false;
@@ -162,7 +162,7 @@ int DirtyJtag::setClkFreq(uint32_t clkHZ)
 					static_cast<uint8_t>(0xff & ((clkHZ / 1000)     )),
 					CMD_STOP};
 	ret = libusb_bulk_transfer(dev_handle, DIRTYJTAG_WRITE_EP,
-			        buf, 4, &actual_length, DIRTYJTAG_TIMEOUT);
+					buf, 4, &actual_length, DIRTYJTAG_TIMEOUT);
 	if (ret < 0) {
 		cerr << "setClkFreq: usb bulk write failed " << ret << endl;
 		return -EXIT_FAILURE;
@@ -171,7 +171,7 @@ int DirtyJtag::setClkFreq(uint32_t clkHZ)
 	return clkHZ;
 }
 
-int DirtyJtag::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
+int DirtyJtag::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer)
 {
 	(void) flush_buffer;
 	int actual_length;
@@ -241,7 +241,7 @@ int DirtyJtag::flush()
 	return 0;
 }
 
-int DirtyJtag::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
+int DirtyJtag::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 {
 	int actual_length;
 	uint32_t real_bit_len = len - (end ? 1 : 0);
@@ -286,7 +286,7 @@ int DirtyJtag::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 
 		actual_length = 0;
 		int ret = libusb_bulk_transfer(dev_handle, DIRTYJTAG_WRITE_EP,
-		        (unsigned char *)tx_buf, (byte_to_send + header_offset),
+				(unsigned char *)tx_buf, (byte_to_send + header_offset),
 				&actual_length, DIRTYJTAG_TIMEOUT);
 		if ((ret < 0) || (actual_length != (int)(byte_to_send + header_offset))) {
 			cerr << "writeTDI: fill: usb bulk write failed " << ret <<

--- a/src/dirtyJtag.hpp
+++ b/src/dirtyJtag.hpp
@@ -25,9 +25,9 @@ class DirtyJtag : public JtagInterface {
 	int setClkFreq(uint32_t clkHZ) override;
 
 	/* TMS */
-	int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) override;
+    int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) override;
 	/* TDI */
-	int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+    int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 	/* clk */
 	int toggleClk(uint8_t tms, uint8_t tdo, uint32_t clk_len) override;
 

--- a/src/efinix.cpp
+++ b/src/efinix.cpp
@@ -415,7 +415,7 @@ bool Efinix::prepare_flash_access()
  *        so to send only a cmd set len to 0 (or omit this param)
  */
 int Efinix::spi_put(uint8_t cmd,
-			uint8_t *tx, uint8_t *rx, uint32_t len)
+			const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int kXferLen = len + 1 + ((rx == NULL) ? 0 : 1);
 	uint8_t jtx[kXferLen];
@@ -440,7 +440,7 @@ int Efinix::spi_put(uint8_t cmd,
 	return 0;
 }
 
-int Efinix::spi_put(uint8_t *tx, uint8_t *rx, uint32_t len)
+int Efinix::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int kXferLen = len + ((rx == NULL) ? 0 : 1);
 	uint8_t jtx[kXferLen];

--- a/src/efinix.cpp
+++ b/src/efinix.cpp
@@ -291,7 +291,8 @@ void Efinix::programSPI(unsigned int offset, const uint8_t *data,
 
 void Efinix::programJTAG(const uint8_t *data, const int length)
 {
-	int xfer_len = 512, tx_end;
+	int xfer_len = 512;
+	Jtag::tapState_t tx_end;
 	uint8_t tx[512];
 
 	if (_fpga_family == TITANIUM_FAMILY)

--- a/src/efinix.hpp
+++ b/src/efinix.hpp
@@ -37,7 +37,7 @@ class Efinix: public Device, SPIInterface {
 		bool bulk_erase_flash() override {
 			printError("bulk erase flash not supported"); return false;}
 		/* not supported in SPI Active mode */
-		int idCode() override {return 0;}
+		uint32_t idCode() override {return 0;}
 		void reset() override;
 
 		/* spi interface */

--- a/src/efinix.hpp
+++ b/src/efinix.hpp
@@ -41,9 +41,9 @@ class Efinix: public Device, SPIInterface {
 		void reset() override;
 
 		/* spi interface */
-		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
+		int spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 			uint32_t len) override;
-		int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) override;
+		int spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len) override;
 		int spi_wait(uint8_t cmd, uint8_t mask, uint8_t cond,
 			uint32_t timeout, bool verbose = false) override;
 

--- a/src/efinixHexParser.cpp
+++ b/src/efinixHexParser.cpp
@@ -23,7 +23,7 @@ int EfinixHexParser::parse()
 	istringstream lineStream(_raw_data);
 
 	while (std::getline(lineStream, buffer, '\n')) {
-		_bit_data += std::stol(buffer, nullptr, 16);
+		_bit_data.push_back(std::stol(buffer, nullptr, 16));
 	}
 	_bit_length = _bit_data.size() * 8;
 

--- a/src/fsparser.cpp
+++ b/src/fsparser.cpp
@@ -136,9 +136,9 @@ int FsParser::parse()
 	 */
 
 	for (auto &&line : _lstRawData) {
-		for (size_t i = 0; i < line.size(); i+=8) {
+		for (size_t i = 0; i < line.size(); i += 8) {
 			uint8_t data = bitToVal(&line[i], 8);
-			_bit_data += (_reverseByte) ? reverseByte(data) : data;
+			_bit_data.push_back((_reverseByte) ? reverseByte(data) : data);
 		}
 	}
 

--- a/src/ftdiJtagBitbang.cpp
+++ b/src/ftdiJtagBitbang.cpp
@@ -116,7 +116,7 @@ int FtdiJtagBitBang::setBitmode(uint8_t mode)
 	return ret;
 }
 
-int FtdiJtagBitBang::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
+int FtdiJtagBitBang::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer)
 {
 	int ret;
 
@@ -162,7 +162,7 @@ int FtdiJtagBitBang::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
 	return len;
 }
 
-int FtdiJtagBitBang::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
+int FtdiJtagBitBang::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 {
 	uint32_t iter;
 	uint32_t xfer_size = (rx) ? _rx_size : _buffer_size;

--- a/src/ftdiJtagBitbang.hpp
+++ b/src/ftdiJtagBitbang.hpp
@@ -31,10 +31,10 @@ class FtdiJtagBitBang : public JtagInterface, private FTDIpp_MPSSE {
 	int setClkFreq(uint32_t clkHZ) override;
 
 	/* TMS */
-	int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) override;
+	int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) override;
 
 	/* TDI */
-	int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+	int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 	int toggleClk(uint8_t tms, uint8_t tdo, uint32_t clk_len) override;
 
 	/*!

--- a/src/ftdiJtagMPSSE.cpp
+++ b/src/ftdiJtagMPSSE.cpp
@@ -107,7 +107,7 @@ void FtdiJtagMPSSE::config_edge()
 	}
 }
 
-int FtdiJtagMPSSE::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
+int FtdiJtagMPSSE::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer)
 {
 	(void) flush_buffer;
 	display("%s %d %d\n", __func__, len, (len/8)+1);
@@ -208,7 +208,7 @@ int FtdiJtagMPSSE::flush()
 	return mpsse_write();
 }
 
-int FtdiJtagMPSSE::writeTDI(uint8_t *tdi, uint8_t *tdo, uint32_t len, bool last)
+int FtdiJtagMPSSE::writeTDI(const uint8_t *tdi, uint8_t *tdo, uint32_t len, bool last)
 {
 	/* 3 possible case :
 	 *  - n * 8bits to send -> use byte command

--- a/src/ftdiJtagMPSSE.hpp
+++ b/src/ftdiJtagMPSSE.hpp
@@ -33,11 +33,11 @@ class FtdiJtagMPSSE : public JtagInterface, public FTDIpp_MPSSE {
 	uint32_t getClkFreq() override {return FTDIpp_MPSSE::getClkFreq();}
 
 	/* TMS */
-	int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) override;
+	int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) override;
 	/* clock */
 	int toggleClk(uint8_t tms, uint8_t tdi, uint32_t clk_len) override;
 	/* TDI */
-	int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+	int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 
 	/*!
 	 * \brief send TMD and TDI and receive tdo bits;

--- a/src/ftdispi.cpp
+++ b/src/ftdispi.cpp
@@ -163,8 +163,8 @@ int FtdiSpi::ft2232_spi_wr_then_rd(
 
 /* Returns 0 upon success, a negative number upon errors. */
 int FtdiSpi::ft2232_spi_wr_and_rd(//struct ftdi_spi *spi,
-			    uint32_t writecnt,
-			    const uint8_t * writearr, uint8_t * readarr)
+				uint32_t writecnt,
+				const uint8_t * writearr, uint8_t * readarr)
 {
 	uint32_t max_xfer = (readarr) ? _buffer_size : 4096;
 	uint8_t buf[max_xfer];
@@ -229,7 +229,7 @@ int FtdiSpi::ft2232_spi_wr_and_rd(//struct ftdi_spi *spi,
 }
 
 /* method spiInterface::spi_put */
-int FtdiSpi::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
+int FtdiSpi::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	uint32_t xfer_len = len + 1;
 	uint8_t jtx[xfer_len];
@@ -252,7 +252,7 @@ int FtdiSpi::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
 }
 
 /* method spiInterface::spi_put */
-int FtdiSpi::spi_put(uint8_t *tx, uint8_t *rx, uint32_t len)
+int FtdiSpi::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	return ft2232_spi_wr_and_rd(len, tx, rx);
 }

--- a/src/ftdispi.hpp
+++ b/src/ftdispi.hpp
@@ -51,9 +51,9 @@ class FtdiSpi : public FTDIpp_MPSSE, SPIInterface {
 							const uint8_t *writearr, uint8_t *readarr);
 
 	/* spi interface */
-	int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
+	int spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 			uint32_t len) override;
-	int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) override;
+	int spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len) override;
 	int spi_wait(uint8_t cmd, uint8_t mask, uint8_t cond,
 			uint32_t timeout, bool verbose=false) override;
 

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -632,7 +632,8 @@ bool Gowin::connectJtagToMCU()
 /* TN653 p. 9 */
 bool Gowin::flashSRAM(const uint8_t *data, int length)
 {
-	int tx_len, tx_end;
+	int tx_len;
+	Jtag::tapState_t tx_end;
 	int byte_length = length / 8;
 
 	ProgressBar progress("Flash SRAM", byte_length, 50, _quiet);

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -400,7 +400,7 @@ bool Gowin::DisableCfg()
 	return pollFlag(STATUS_SYSTEM_EDIT_MODE, 0);
 }
 
-int Gowin::idCode()
+uint32_t Gowin::idCode()
 {
 	uint8_t device_id[4];
 	wr_rd(READ_IDCODE, NULL, 0, device_id, 4);

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -175,7 +175,7 @@ Gowin::Gowin(Jtag *jtag, const string filename, const string &file_type, std::st
 	if (mcufw.size() > 0) {
 		if (idcode != 0x0100981b)
 			throw std::runtime_error("Microcontroller firmware flashing only supported on GW1NSR-4C");
-		
+
 		_mcufw = new RawParser(mcufw, false);
 
 		if (_mcufw->parse() == EXIT_FAILURE) {
@@ -204,12 +204,12 @@ void Gowin::reset()
 
 void Gowin::programFlash()
 {
-	uint8_t *data = _fs->getData();
+	const uint8_t *data = _fs->getData();
 	int length = _fs->getLength();
-	
-	uint8_t *mcu_data = nullptr;
+
+	const uint8_t *mcu_data = nullptr;
 	int mcu_length = 0;
-	
+
 	if (_mcufw) {
 		mcu_data = _mcufw->getData();
 		mcu_length = _mcufw->getLength();
@@ -256,7 +256,7 @@ void Gowin::programFlash()
 
 void Gowin::program(unsigned int offset, bool unprotect_flash)
 {
-	uint8_t *data;
+	const uint8_t *data;
 	int length;
 
 	if (_mode == NONE_MODE || !_fs)
@@ -456,7 +456,7 @@ bool Gowin::wr_rd(uint8_t cmd,
 				printf("%02x ", xfer_rx[i]);
 			printf("\n");
 		}
-	    for (i = 0; i < rx_len; i++)
+		for (i = 0; i < rx_len; i++)
 			rx[i] = (xfer_rx[i]);
 	}
 	return true;
@@ -518,7 +518,7 @@ bool Gowin::pollFlag(uint32_t mask, uint32_t value)
 }
 
 /* TN653 p. 17-21 */
-bool Gowin::flashFLASH(uint32_t page, uint8_t *data, int length)
+bool Gowin::flashFLASH(uint32_t page, const uint8_t *data, int length)
 {
 	uint8_t tx[4] = {0x4E, 0x31, 0x57, 0x47};
 	uint8_t tmp[4];
@@ -630,7 +630,7 @@ bool Gowin::connectJtagToMCU()
 }
 
 /* TN653 p. 9 */
-bool Gowin::flashSRAM(uint8_t *data, int length)
+bool Gowin::flashSRAM(const uint8_t *data, int length)
 {
 	int tx_len, tx_end;
 	int byte_length = length / 8;
@@ -748,7 +748,7 @@ bool Gowin::eraseSRAM()
 	_jtag->shiftDR(_wr, _rd, _len); \
 	_jtag->toggleClk(6); } while (0)
 
-int Gowin::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
+int Gowin::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	uint8_t jrx[len+1], jtx[len+1];
 	jtx[0] = cmd;
@@ -762,7 +762,7 @@ int Gowin::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
 	return ret;
 }
 
-int Gowin::spi_put(uint8_t *tx, uint8_t *rx, uint32_t len)
+int Gowin::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	if (is_gw2a) {
 		uint8_t jtx[len];

--- a/src/gowin.hpp
+++ b/src/gowin.hpp
@@ -22,7 +22,7 @@ class Gowin: public Device, SPIInterface {
 				Device::prog_type_t prg_type, bool external_flash,
 				bool verify, int8_t verbose);
 		~Gowin();
-		int idCode() override;
+		uint32_t idCode() override;
 		void reset() override;
 		void program(unsigned int offset, bool unprotect_flash) override;
 		void programFlash();

--- a/src/gowin.hpp
+++ b/src/gowin.hpp
@@ -36,9 +36,9 @@ class Gowin: public Device, SPIInterface {
 			printError("unprotect flash not supported"); return false;}
 		virtual bool bulk_erase_flash() override {
 			printError("bulk erase flash not supported"); return false;}
-		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
+		int spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 			uint32_t len) override;
-		int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) override;
+		int spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len) override;
 		int spi_wait(uint8_t cmd, uint8_t mask, uint8_t cond,
 			uint32_t timeout, bool verbose) override;
 
@@ -50,8 +50,8 @@ class Gowin: public Device, SPIInterface {
 		bool pollFlag(uint32_t mask, uint32_t value);
 		bool eraseSRAM();
 		bool eraseFLASH();
-		bool flashSRAM(uint8_t *data, int length);
-		bool flashFLASH(uint32_t page, uint8_t *data, int length);
+		bool flashSRAM(const uint8_t *data, int length);
+		bool flashFLASH(uint32_t page, const uint8_t *data, int length);
 		void displayReadReg(uint32_t dev);
 		uint32_t readStatusReg();
 		uint32_t readUserCode();

--- a/src/ice40.cpp
+++ b/src/ice40.cpp
@@ -60,7 +60,7 @@ void Ice40::reset()
 /* cf. TN1248 (iCE40 Programming and Configuration)
  * Appendix A. SPI Slave Configuration Procedure
  */
-bool Ice40::program_cram(uint8_t *data, uint32_t length)
+bool Ice40::program_cram(const uint8_t *data, uint32_t length)
 {
 	uint32_t timeout = 1000;
 
@@ -78,7 +78,7 @@ bool Ice40::program_cram(uint8_t *data, uint32_t length)
 	/* load configuration data MSB first
 	 */
 	ProgressBar progress("Loading to CRAM", length, 50, _verbose);
-	uint8_t *ptr = data;
+	const uint8_t *ptr = data;
 	int size = 0;
 	for (uint32_t addr = 0; addr < length; addr += size, ptr+=size) {
 		size = (addr + 256 > length)?(length-addr) : 256;
@@ -127,7 +127,7 @@ void Ice40::program(unsigned int offset, bool unprotect_flash)
 		return;
 	}
 
-	uint8_t *data = bit.getData();
+	const uint8_t *data = bit.getData();
 	int length = bit.getLength() / 8;
 
 	if (_mode == Device::MEM_MODE) {

--- a/src/ice40.hpp
+++ b/src/ice40.hpp
@@ -22,7 +22,7 @@ class Ice40: public Device, SPIInterface {
 		~Ice40();
 
 		void program(unsigned int offset, bool unprotect_flash) override;
-		bool program_cram(uint8_t *data, uint32_t length);
+		bool program_cram(const uint8_t *data, uint32_t length);
 		bool dumpFlash(uint32_t base_addr, uint32_t len) override;
 		bool protect_flash(uint32_t len) override;
 		bool unprotect_flash() override;
@@ -31,12 +31,12 @@ class Ice40: public Device, SPIInterface {
 		int idCode() override {return 0;}
 		void reset() override;
 
-		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
+		int spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 				uint32_t len) override {
 			(void)cmd; (void)tx; (void)rx; (void)len;
 			return 0;
 		}
-		int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) override {
+		int spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len) override {
 			(void)tx; (void)rx; (void)len;
 			return 0;
 		}

--- a/src/ice40.hpp
+++ b/src/ice40.hpp
@@ -28,7 +28,7 @@ class Ice40: public Device, SPIInterface {
 		bool unprotect_flash() override;
 		bool bulk_erase_flash() override;
 		/* not supported in SPI Active mode */
-		int idCode() override {return 0;}
+		uint32_t idCode() override {return 0;}
 		void reset() override;
 
 		int spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx,

--- a/src/jlink.cpp
+++ b/src/jlink.cpp
@@ -26,12 +26,12 @@ using namespace std;
 
 // convert 2Byte to 1 short
 #define CONV_16B(_val) ((((uint16_t) _val[0]) << 0) | \
-					    (((uint16_t) _val[1]) << 8))
+						(((uint16_t) _val[1]) << 8))
 // convert 4Byte to 1 word
 #define CONV_32B(_val) ((((uint32_t) _val[0]) <<  0) | \
-					    (((uint32_t) _val[1]) <<  8) | \
-					    (((uint32_t) _val[2]) << 16) | \
-					    (((uint32_t) _val[3]) << 24))
+						(((uint32_t) _val[1]) <<  8) | \
+						(((uint32_t) _val[2]) << 16) | \
+						(((uint32_t) _val[3]) << 24))
 // a 0-byte is introduce when reading a packet with
 // size multiple of 64 Byte but < 0x8000
 #define HAS_0BYTE(_len) ((_len != 0) && (_len % 64 == 0) && (_len != 0x8000))
@@ -89,7 +89,7 @@ Jlink::~Jlink()
 	libusb_exit(jlink_ctx);
 }
 
-int Jlink::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
+int Jlink::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer)
 {
 	// empty buffer
 	// if asked flush
@@ -123,7 +123,7 @@ int Jlink::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
 	return len;
 }
 
-int Jlink::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
+int Jlink::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 {
 	if (len == 0)  // nothing to do
 		return 0;
@@ -132,7 +132,8 @@ int Jlink::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 
 	uint32_t xfer_len = BUF_SIZE * 8;  // default to buffer capacity
 	uint8_t tms = (_last_tms) ? 0xff : 0x00;  // set tms byte
-	uint8_t *tx_ptr = tx, *rx_ptr = rx;  // use pointer to simplify algo
+	const uint8_t *tx_ptr = tx;
+	uint8_t *rx_ptr = rx;  // use pointer to simplify algo
 
 	/* write by burst */
 	for (uint32_t rest = 0; rest < len; rest += xfer_len) {
@@ -477,9 +478,9 @@ int Jlink::get_hw_version()
 		return -1;
 
 	_hw_type = (version / 1000000) % 100;
-    _major = (version / 10000) % 100;
-    _minor = (version / 100) % 100;
-    _revision = version % 100;
+	_major = (version / 10000) % 100;
+	_minor = (version / 100) % 100;
+	_revision = version % 100;
 
 	if (_debug)
 		printf("%08x ", version);

--- a/src/jlink.hpp
+++ b/src/jlink.hpp
@@ -44,7 +44,7 @@ class Jlink: public JtagInterface {
 		 * \param[in] flush_buffer: force buffer to be send or not
 		 * \return <= 0 if something wrong, len otherwise
 		 */
-		int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) override;
+		int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) override;
 
 		/*!
 		 * \brief write and read len bits with optional tms set to 1 if end
@@ -54,7 +54,7 @@ class Jlink: public JtagInterface {
 		 * \param[in] end: if true tms is set to one with the last tdi bit
 		 * \return <= 0 if something wrong, len otherwise
 		 */
-		int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+		int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 
 		/*!
 		 * \brief access ll_write outer this class / directly receives

--- a/src/jtag.cpp
+++ b/src/jtag.cpp
@@ -298,7 +298,7 @@ void Jtag::go_test_logic_reset()
 	_state = TEST_LOGIC_RESET;
 }
 
-int Jtag::read_write(unsigned char *tdi, unsigned char *tdo, int len, char last)
+int Jtag::read_write(const uint8_t *tdi, unsigned char *tdo, int len, char last)
 {
 	flushTMS(false);
 	_jtag->writeTDI(tdi, tdo, len, last);
@@ -317,7 +317,7 @@ void Jtag::toggleClk(int nb)
 	return;
 }
 
-int Jtag::shiftDR(unsigned char *tdi, unsigned char *tdo, int drlen, int end_state)
+int Jtag::shiftDR(const uint8_t *tdi, unsigned char *tdo, int drlen, int end_state)
 {
 	/* get number of devices in the JTAG chain
 	 * after the selected one
@@ -361,7 +361,7 @@ int Jtag::shiftDR(unsigned char *tdi, unsigned char *tdo, int drlen, int end_sta
 			uint8_t tx[n];
 			memset(tx, 0xff, n);
 			read_write(tx, NULL, bits_after, 1);  // its the last force
-			                                      // tms high with last bit
+												  // tms high with last bit
 		}
 
 		/* move to end_state */

--- a/src/jtag.cpp
+++ b/src/jtag.cpp
@@ -440,7 +440,7 @@ int Jtag::shiftIR(unsigned char *tdi, unsigned char *tdo, int irlen, tapState_t 
 	return 0;
 }
 
-void Jtag::set_state(int newState)
+void Jtag::set_state(tapState_t newState)
 {
 	unsigned char tms = 0;
 	while (newState != _state) {
@@ -621,6 +621,9 @@ void Jtag::set_state(int newState)
 				_state = SELECT_DR_SCAN;
 			}
 			break;
+		case UNKNOWN:;
+			// UNKNOWN should not be valid...
+			throw std::exception();
 		}
 
 		setTMS(tms);

--- a/src/jtag.cpp
+++ b/src/jtag.cpp
@@ -317,7 +317,7 @@ void Jtag::toggleClk(int nb)
 	return;
 }
 
-int Jtag::shiftDR(const uint8_t *tdi, unsigned char *tdo, int drlen, int end_state)
+int Jtag::shiftDR(const uint8_t *tdi, unsigned char *tdo, int drlen, tapState_t end_state)
 {
 	/* get number of devices in the JTAG chain
 	 * after the selected one
@@ -370,7 +370,7 @@ int Jtag::shiftDR(const uint8_t *tdi, unsigned char *tdo, int drlen, int end_sta
 	return 0;
 }
 
-int Jtag::shiftIR(unsigned char tdi, int irlen, int end_state)
+int Jtag::shiftIR(unsigned char tdi, int irlen, tapState_t end_state)
 {
 	if (irlen > 8) {
 		cerr << "Error: this method this direct char don't support more than 1 byte" << endl;
@@ -379,7 +379,7 @@ int Jtag::shiftIR(unsigned char tdi, int irlen, int end_state)
 	return shiftIR(&tdi, NULL, irlen, end_state);
 }
 
-int Jtag::shiftIR(unsigned char *tdi, unsigned char *tdo, int irlen, int end_state)
+int Jtag::shiftIR(unsigned char *tdi, unsigned char *tdo, int irlen, tapState_t end_state)
 {
 	display("%s: avant shiftIR\n", __func__);
 	int bypass_after = 0;

--- a/src/jtag.hpp
+++ b/src/jtag.hpp
@@ -67,22 +67,6 @@ class Jtag {
 	 * \return a pointer instance of JtagInterface
 	 */
 	JtagInterface *get_ll_class() {return _jtag;}
-
-	int shiftIR(unsigned char *tdi, unsigned char *tdo, int irlen,
-		int end_state = RUN_TEST_IDLE);
-	int shiftIR(unsigned char tdi, int irlen,
-		int end_state = RUN_TEST_IDLE);
-	int shiftDR(const uint8_t *tdi, unsigned char *tdo, int drlen,
-		int end_state = RUN_TEST_IDLE);
-	int read_write(const uint8_t *tdi, unsigned char *tdo, int len, char last);
-
-	void toggleClk(int nb);
-	void go_test_logic_reset();
-	void set_state(int newState);
-	int flushTMS(bool flush_buffer = false);
-	void flush() {flushTMS(); _jtag->flush();}
-	void setTMS(unsigned char tms);
-
 	enum tapState_t {
 		TEST_LOGIC_RESET = 0,
 		RUN_TEST_IDLE = 1,
@@ -102,6 +86,22 @@ class Jtag {
 		UPDATE_IR = 15,
 		UNKNOWN = 999
 	};
+
+	int shiftIR(unsigned char *tdi, unsigned char *tdo, int irlen,
+				Jtag::tapState_t end_state = RUN_TEST_IDLE);
+	int shiftIR(unsigned char tdi, int irlen,
+		Jtag::tapState_t end_state = RUN_TEST_IDLE);
+	int shiftDR(const uint8_t *tdi, unsigned char *tdo, int drlen,
+		Jtag::tapState_t end_state = RUN_TEST_IDLE);
+	int read_write(const uint8_t *tdi, unsigned char *tdo, int len, char last);
+
+	void toggleClk(int nb);
+	void go_test_logic_reset();
+	void set_state(int newState);
+	int flushTMS(bool flush_buffer = false);
+	void flush() {flushTMS(); _jtag->flush();}
+	void setTMS(unsigned char tms);
+
 	const char *getStateName(tapState_t s);
 
 	/* utilities */

--- a/src/jtag.hpp
+++ b/src/jtag.hpp
@@ -72,9 +72,9 @@ class Jtag {
 		int end_state = RUN_TEST_IDLE);
 	int shiftIR(unsigned char tdi, int irlen,
 		int end_state = RUN_TEST_IDLE);
-	int shiftDR(unsigned char *tdi, unsigned char *tdo, int drlen,
+	int shiftDR(const uint8_t *tdi, unsigned char *tdo, int drlen,
 		int end_state = RUN_TEST_IDLE);
-	int read_write(unsigned char *tdi, unsigned char *tdo, int len, char last);
+	int read_write(const uint8_t *tdi, unsigned char *tdo, int len, char last);
 
 	void toggleClk(int nb);
 	void go_test_logic_reset();

--- a/src/jtag.hpp
+++ b/src/jtag.hpp
@@ -67,6 +67,7 @@ class Jtag {
 	 * \return a pointer instance of JtagInterface
 	 */
 	JtagInterface *get_ll_class() {return _jtag;}
+
 	enum tapState_t {
 		TEST_LOGIC_RESET = 0,
 		RUN_TEST_IDLE = 1,
@@ -88,16 +89,16 @@ class Jtag {
 	};
 
 	int shiftIR(unsigned char *tdi, unsigned char *tdo, int irlen,
-				Jtag::tapState_t end_state = RUN_TEST_IDLE);
+		tapState_t end_state = RUN_TEST_IDLE);
 	int shiftIR(unsigned char tdi, int irlen,
-		Jtag::tapState_t end_state = RUN_TEST_IDLE);
+		tapState_t end_state = RUN_TEST_IDLE);
 	int shiftDR(const uint8_t *tdi, unsigned char *tdo, int drlen,
-		Jtag::tapState_t end_state = RUN_TEST_IDLE);
+		tapState_t end_state = RUN_TEST_IDLE);
 	int read_write(const uint8_t *tdi, unsigned char *tdo, int len, char last);
 
 	void toggleClk(int nb);
 	void go_test_logic_reset();
-	void set_state(int newState);
+	void set_state(tapState_t newState);
 	int flushTMS(bool flush_buffer = false);
 	void flush() {flushTMS(); _jtag->flush();}
 	void setTMS(unsigned char tms);
@@ -119,7 +120,7 @@ class Jtag {
 	 */
 	bool search_and_insert_device_with_idcode(uint32_t idcode);
 	bool _verbose;
-	int _state;
+	tapState_t _state;
 	int _tms_buffer_size;
 	int _num_tms;
 	unsigned char *_tms_buffer;

--- a/src/jtagInterface.hpp
+++ b/src/jtagInterface.hpp
@@ -30,7 +30,7 @@ class JtagInterface {
 	 * \param len: number of bit to send
 	 * \return number of bit send/received
 	 */
-	virtual int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) = 0;
+	virtual int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) = 0;
 
 	/*!
 	 * \brief send TDI bits (mainly in shift DR/IR state)
@@ -41,7 +41,7 @@ class JtagInterface {
 	 *             but only in shift[i|d]r, if end is false tms remain the same.
 	 * \return number of bit written and/or read
 	 */
-	virtual int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) = 0;
+	virtual int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) = 0;
 	/*!
 	 * \brief send TMD and TDI and receive tdo bits;
 	 * \param tms: array of TMS values (used to write)

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -232,25 +232,25 @@ void displayFeabits(uint16_t _featbits)
 			printf(" Error!\n");
 	}
 	printf("\tMaster Mode SPI                          : %s\n",
-	    (((_featbits>>11)&0x01)?"enable":"disable"));
+		(((_featbits>>11)&0x01)?"enable":"disable"));
 	printf("\tI2c port                                 : %s\n",
-	    (((_featbits>>10)&0x01)?"disable":"enable"));
+		(((_featbits>>10)&0x01)?"disable":"enable"));
 	printf("\tSlave SPI port                           : %s\n",
-	    (((_featbits>>9)&0x01)?"disable":"enable"));
+		(((_featbits>>9)&0x01)?"disable":"enable"));
 	printf("\tJTAG port                                : %s\n",
-	    (((_featbits>>8)&0x01)?"disable":"enable"));
+		(((_featbits>>8)&0x01)?"disable":"enable"));
 	printf("\tDONE                                     : %s\n",
-	    (((_featbits>>7)&0x01)?"enable":"disable"));
+		(((_featbits>>7)&0x01)?"enable":"disable"));
 	printf("\tINITN                                    : %s\n",
-	    (((_featbits>>6)&0x01)?"enable":"disable"));
+		(((_featbits>>6)&0x01)?"enable":"disable"));
 	printf("\tPROGRAMN                                 : %s\n",
-	    (((_featbits>>5)&0x01)?"disable":"enable"));
+		(((_featbits>>5)&0x01)?"disable":"enable"));
 	printf("\tMy_ASSP                                  : %s\n",
-	    (((_featbits>>4)&0x01)?"enable":"disable"));
+		(((_featbits>>4)&0x01)?"enable":"disable"));
 	printf("\tPassword (Flash Protect Key) Protect All : %s\n",
-	    (((_featbits>>3)&0x01)?"Enabled" : "Disabled"));
+		(((_featbits>>3)&0x01)?"Enabled" : "Disabled"));
 	printf("\tPassword (Flash Protect Key) Protect     : %s\n",
-	    (((_featbits>>2)&0x01)?"Enabled" : "Disabled"));
+		(((_featbits>>2)&0x01)?"Enabled" : "Disabled"));
 }
 
 bool Lattice::checkStatus(uint32_t val, uint32_t mask)
@@ -330,7 +330,7 @@ bool Lattice::program_mem()
 	_jtag->set_state(Jtag::RUN_TEST_IDLE);
 	_jtag->toggleClk(1000);
 
-	uint8_t *data = _bit.getData();
+	const uint8_t *data = _bit.getData();
 	int length = _bit.getLength()/8;
 	wr_rd(0x7A, NULL, 0, NULL, 0);
 	_jtag->set_state(Jtag::RUN_TEST_IDLE);
@@ -1296,11 +1296,11 @@ uint16_t Lattice::getUFMStartPageFromJEDEC(JedParser *_jed, int id)
 	uint32_t bit_offset = _jed->offset_for_section(id);
 	/* Convert to starting page, relative to Configuration Flash's page 0.
 	For 7000 parts only, first UFM page starts 16 bytes (1 page) after
-        the last Configuration Flash page, based on looking at
-        Diamond-generated JEDECs.
+		the last Configuration Flash page, based on looking at
+		Diamond-generated JEDECs.
 
-        For all other parts, the first UFM page immediately follows the last
-        Configuration Flash page. */
+		For all other parts, the first UFM page immediately follows the last
+		Configuration Flash page. */
 	uint16_t raw_page_offset = bit_offset / 128;
 
 	/* Raw page offsets won't overlap- see Lattice TN-02155, page 49. So we
@@ -1329,7 +1329,7 @@ uint16_t Lattice::getUFMStartPageFromJEDEC(JedParser *_jed, int id)
 /* SPI implementation */
 /* ------------------ */
 
-int Lattice::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
+int Lattice::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int xfer_len = len + 1;
 	uint8_t jtx[xfer_len];
@@ -1355,7 +1355,7 @@ int Lattice::spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx, uint32_t len)
 	return 0;
 }
 
-int Lattice::spi_put(uint8_t *tx, uint8_t *rx, uint32_t len)
+int Lattice::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int xfer_len = len;
 	uint8_t jtx[xfer_len];
@@ -2009,7 +2009,7 @@ bool Lattice::program_pubkey_MachXO3D()
 		printSuccess("DONE");
 	}
 
-	uint8_t* data = _pk.getData();
+	const uint8_t* data = _pk.getData();
 	len =  _pk.getLength()/8;
 
 	if (data[0] == 0x0f && data[1] == 0xf0) {

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -338,7 +338,7 @@ bool Lattice::program_mem()
 
 	uint8_t tmp[1024];
 	int size = 1024;
-	int next_state = Jtag::SHIFT_DR;
+	Jtag::tapState_t next_state = Jtag::SHIFT_DR;
 
 	ProgressBar progress("Loading", length, 50, _quiet);
 
@@ -433,7 +433,7 @@ bool Lattice::program_intFlash(ConfigBitstreamParser *_cbp)
 
 				if(ufm_start > 2045) {
 					printError("UFM section detected in JEDEC file, but "
-					 	"calculated flash start address was out of bounds");
+						"calculated flash start address was out of bounds");
 					return false;
 				}
 			} else if (note == "END CONFIG DATA") {
@@ -1308,7 +1308,7 @@ uint16_t Lattice::getUFMStartPageFromJEDEC(JedParser *_jed, int id)
 	addres.
 	TODO: In any case, JEDEC files don't carry part information. Verify against
 	IDCODE read previously? */
-	
+
 	if(raw_page_offset > 9211) {
 		return raw_page_offset - 9211 - 1; // 7000
 	} else if(raw_page_offset > 5758) {

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -843,7 +843,7 @@ bool Lattice::DisableCfg()
 	return true;
 }
 
-int Lattice::idCode()
+uint32_t Lattice::idCode()
 {
 	uint8_t device_id[4];
 	wr_rd(READ_DEVICE_ID_CODE, NULL, 0, device_id, 4);
@@ -1308,7 +1308,7 @@ uint16_t Lattice::getUFMStartPageFromJEDEC(JedParser *_jed, int id)
 	addres.
 	TODO: In any case, JEDEC files don't carry part information. Verify against
 	IDCODE read previously? */
-
+	
 	if(raw_page_offset > 9211) {
 		return raw_page_offset - 9211 - 1; // 7000
 	} else if(raw_page_offset > 5758) {

--- a/src/lattice.hpp
+++ b/src/lattice.hpp
@@ -55,9 +55,9 @@ class Lattice: public Device, SPIInterface {
 		}
 
 		/* spi interface */
-		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
+		int spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 		uint32_t len) override;
-		int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) override;
+		int spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len) override;
 		int spi_wait(uint8_t cmd, uint8_t mask, uint8_t cond,
 				uint32_t timeout, bool verbose = false) override;
 

--- a/src/lattice.hpp
+++ b/src/lattice.hpp
@@ -23,7 +23,7 @@ class Lattice: public Device, SPIInterface {
 		Lattice(Jtag *jtag, std::string filename, const std::string &file_type,
 			Device::prog_type_t prg_type, std::string flash_sector, bool verify,
 			int8_t verbose);
-		int idCode() override;
+		uint32_t idCode() override;
 		int userCode();
 		void reset() override {}
 		void program(unsigned int offset, bool unprotect_flash) override;

--- a/src/libgpiodJtagBitbang.cpp
+++ b/src/libgpiodJtagBitbang.cpp
@@ -272,8 +272,8 @@ int LibgpiodJtagBitbang::read_tdo()
 #ifdef GPIOD_APIV2
 	gpiod_line_value req = gpiod_line_request_get_value(
 		_tdo_request, _tdo_pin);
-        if (req == GPIOD_LINE_VALUE_ERROR)
-        {
+		if (req == GPIOD_LINE_VALUE_ERROR)
+		{
 		display("Error reading TDO line\n");
 		throw std::runtime_error("Error reading TDO line\n");
 	}
@@ -291,7 +291,7 @@ int LibgpiodJtagBitbang::setClkFreq(__attribute__((unused)) uint32_t clkHZ)
 	return 0;
 }
 
-int LibgpiodJtagBitbang::writeTMS(uint8_t *tms_buf, uint32_t len,
+int LibgpiodJtagBitbang::writeTMS(const uint8_t *tms_buf, uint32_t len,
 		__attribute__((unused)) bool flush_buffer)
 {
 	int tms;
@@ -311,7 +311,7 @@ int LibgpiodJtagBitbang::writeTMS(uint8_t *tms_buf, uint32_t len,
 	return len;
 }
 
-int LibgpiodJtagBitbang::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
+int LibgpiodJtagBitbang::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 {
 	int tms = _curr_tms;
 	int tdi = _curr_tdi;

--- a/src/libgpiodJtagBitbang.hpp
+++ b/src/libgpiodJtagBitbang.hpp
@@ -33,8 +33,8 @@ class LibgpiodJtagBitbang : public JtagInterface {
 	virtual ~LibgpiodJtagBitbang();
 
 	int setClkFreq(uint32_t clkHZ) override;
-	int writeTMS(uint8_t *tms_buf, uint32_t len, bool flush_buffer) override;
-	int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+	int writeTMS(const uint8_t *tms_buf, uint32_t len, bool flush_buffer) override;
+	int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 	int toggleClk(uint8_t tms, uint8_t tdo, uint32_t clk_len) override;
 
 	int get_buffer_size() override { return 0; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
 			/* index_chain file_size target_flash external_flash altsetting */
 			-1,            0,        "primary",   false,         -1,
 			/* vid, pid, index bus_addr, device_addr */
-			    0,   0,   -1,     0,         0,
+				0,   0,   -1,     0,         0,
 			"127.0.0.1", 0, false, false, "", false, false,
 			/* xvc server */
 			false, 3721, "-",
@@ -533,7 +533,7 @@ int main(int argc, char **argv)
 		return EXIT_SUCCESS;
 	}
 
-    /* check if selected device is supported
+	/* check if selected device is supported
 	 * mainly used in conjunction with --index-chain
 	 */
 	if (fpga_list.find(idcode) == fpga_list.end()) {

--- a/src/remoteBitbang_client.cpp
+++ b/src/remoteBitbang_client.cpp
@@ -76,7 +76,7 @@ RemoteBitbang_client::~RemoteBitbang_client()
 	close(_sock);
 }
 
-int RemoteBitbang_client::writeTMS(uint8_t *tms, uint32_t len,
+int RemoteBitbang_client::writeTMS(const uint8_t *tms, uint32_t len,
 		bool flush_buffer)
 {
 	// empty buffer
@@ -100,7 +100,7 @@ int RemoteBitbang_client::writeTMS(uint8_t *tms, uint32_t len,
 	return len;
 }
 
-int RemoteBitbang_client::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len,
+int RemoteBitbang_client::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len,
 		bool end)
 {
 	if (len == 0)  // nothing to do
@@ -190,7 +190,7 @@ bool RemoteBitbang_client::open_connection(const string &ip_addr)
 	}
 
 	int one = 1;
-    setsockopt(_sock, IPPROTO_TCP, TCP_NODELAY, (const char *)&one,
+	setsockopt(_sock, IPPROTO_TCP, TCP_NODELAY, (const char *)&one,
 			sizeof(one));
 
 	return true;

--- a/src/remoteBitbang_client.hpp
+++ b/src/remoteBitbang_client.hpp
@@ -43,7 +43,7 @@ class RemoteBitbang_client: public JtagInterface {
 		 * \param[in] flush_buffer: force buffer to be send or not
 		 * \return <= 0 if something wrong, len otherwise
 		 */
-		int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) override;
+		int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) override;
 
 		/*!
 		 * \brief write and read len bits with optional tms set to 1 if end
@@ -53,7 +53,7 @@ class RemoteBitbang_client: public JtagInterface {
 		 * \param[in] end: if true tms is set to one with the last tdi bit
 		 * \return <= 0 if something wrong, len otherwise
 		 */
-		int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+		int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 
 		/*!
 		 * \brief send a serie of clock cycle with constant TMS and TDI

--- a/src/spiFlash.cpp
+++ b/src/spiFlash.cpp
@@ -233,7 +233,7 @@ int SPIFlash::sectors_erase(int base_addr, int size)
 	return ret;
 }
 
-int SPIFlash::write_page(int addr, uint8_t *data, int len)
+int SPIFlash::write_page(int addr, const uint8_t *data, int len)
 {
 	uint32_t addr_len;
 	uint8_t write_cmd;
@@ -340,7 +340,7 @@ bool SPIFlash::dump(const std::string &filename, const int &base_addr,
 	return true;
 }
 
-int SPIFlash::erase_and_prog(int base_addr, uint8_t *data, int len)
+int SPIFlash::erase_and_prog(int base_addr, const uint8_t *data, int len)
 {
 	if (_jedec_id == 0) {
 		try {
@@ -435,7 +435,7 @@ int SPIFlash::erase_and_prog(int base_addr, uint8_t *data, int len)
 	if (sectors_erase(base_addr, len) == -1)
 		return -1;
 
-	uint8_t *ptr = data;
+	const uint8_t *ptr = data;
 	int size = 0;
 	for (int addr = 0; addr < len; addr += size, ptr+=size) {
 		size = (addr + 256 > len)?(len-addr) : 256;

--- a/src/spiFlash.hpp
+++ b/src/spiFlash.hpp
@@ -64,7 +64,7 @@ class SPIFlash {
 		 */
 		int sectors_erase(int base_addr, int len);
 		/* write */
-		int write_page(int addr, uint8_t *data, int len);
+		int write_page(int addr, const uint8_t *data, int len);
 		/* read */
 		int read(int base_addr, uint8_t *data, int len);
 		/*!
@@ -79,7 +79,7 @@ class SPIFlash {
 		bool dump(const std::string &filename, const int &base_addr,
 				const int &len, int rd_burst = 0);
 		/* combo flash + erase */
-		int erase_and_prog(int base_addr, uint8_t *data, int len);
+		int erase_and_prog(int base_addr, const uint8_t *data, int len);
 		/*!
 		 * \brief check if area base_addr to base_addr + len match
 		 *        data content

--- a/src/spiInterface.cpp
+++ b/src/spiInterface.cpp
@@ -116,7 +116,7 @@ bool SPIInterface::bulk_erase_flash()
 	return post_flash_access() && ret;
 }
 
-bool SPIInterface::write(uint32_t offset, uint8_t *data, uint32_t len,
+bool SPIInterface::write(uint32_t offset, const uint8_t *data, uint32_t len,
 		bool unprotect_flash)
 {
 	bool ret = true;

--- a/src/spiInterface.hpp
+++ b/src/spiInterface.hpp
@@ -44,7 +44,7 @@ class SPIInterface {
 	 * \param[in] verbose: verbose level
 	 * \return false when something fails
 	 */
-	bool write(uint32_t offset, uint8_t *data, uint32_t len,
+	bool write(uint32_t offset, const uint8_t *data, uint32_t len,
 		bool unprotect_flash);
 
 	/*!
@@ -78,7 +78,7 @@ class SPIInterface {
 	 *                 to send only a cmd set len to 0
 	 * \return 0 when success
 	 */
-	virtual int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
+	virtual int spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 						uint32_t len) = 0;
 
 	/*!
@@ -88,7 +88,7 @@ class SPIInterface {
 	 * \param[in] len: number of byte to send/receive
 	 * \return 0 when success
 	 */
-	virtual int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) = 0;
+	virtual int spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len) = 0;
 
 	/*!
 	 * \brief wait until register content and mask match cond, or timeout

--- a/src/svf_jtag.cpp
+++ b/src/svf_jtag.cpp
@@ -217,12 +217,12 @@ void SVF_jtag::parse_runtest(vector<string> const &vstr)
 		end_state = fsm_state[*res];
 	}
 	if (run_state != -1) {
-		_run_state = run_state;
+		_run_state = (Jtag::tapState_t)run_state;
 	}
 	if (end_state != -1) {
-		_end_state = end_state;
+		_end_state = (Jtag::tapState_t)end_state;
 	} else if (run_state != -1) {
-		_end_state = run_state;
+		_end_state = (Jtag::tapState_t)run_state;
 	}
 	_jtag->set_state(_run_state);
 	_jtag->toggleClk(nb_iter);
@@ -336,7 +336,7 @@ void SVF_jtag::handle_instruction(vector<string> const &vstr)
 
 SVF_jtag::SVF_jtag(Jtag *jtag, bool verbose):_verbose(verbose), _freq_hz(0),
 	_enddr((Jtag::tapState_t)fsm_state["IDLE"]), _endir((Jtag::tapState_t)fsm_state["IDLE"]),
-	_run_state(fsm_state["IDLE"]), _end_state(fsm_state["IDLE"])
+	_run_state((Jtag::tapState_t)fsm_state["IDLE"]), _end_state((Jtag::tapState_t)fsm_state["IDLE"])
 
 {
 	_jtag = jtag;

--- a/src/svf_jtag.cpp
+++ b/src/svf_jtag.cpp
@@ -245,13 +245,13 @@ void SVF_jtag::handle_instruction(vector<string> const &vstr)
 		if (_verbose) cout << "trst value : " << vstr[1] << endl;
 	} else if (!vstr[0].compare("ENDDR")) {
 		if (_verbose) cout << "enddr value : " << vstr[1] << endl;
-		_enddr = fsm_state[vstr[1]];
+		_enddr = (Jtag::tapState_t)fsm_state[vstr[1]];
 	} else if (!vstr[0].compare("ENDIR")) {
 		if (_verbose) cout << "endir value : " << vstr[1] << endl;
-		_endir = fsm_state[vstr[1]];
+		_endir = (Jtag::tapState_t)fsm_state[vstr[1]];
 	} else if (!vstr[0].compare("STATE")) {
 		if (_verbose) cout << "state value : " << vstr[1] << endl;
-		_jtag->set_state(fsm_state[vstr[1]]);
+		_jtag->set_state((Jtag::tapState_t)fsm_state[vstr[1]]);
 	} else if (!vstr[0].compare("RUNTEST")) {
 		parse_runtest(vstr);
 	} else if (!vstr[0].compare("HIR")) {
@@ -284,7 +284,7 @@ void SVF_jtag::handle_instruction(vector<string> const &vstr)
 		parse_XYR(vstr, sir);
 		if (_verbose) {
 			for (auto &&t : vstr)
-			 	cout << t << " ";
+				cout << t << " ";
 			cout << endl;
 			cout << "\tlen   : " << sir.len << endl;
 			cout << "\ttdo   : " << sir.tdo.size()*4 << endl;
@@ -335,7 +335,7 @@ void SVF_jtag::handle_instruction(vector<string> const &vstr)
 }
 
 SVF_jtag::SVF_jtag(Jtag *jtag, bool verbose):_verbose(verbose), _freq_hz(0),
-	_enddr(fsm_state["IDLE"]), _endir(fsm_state["IDLE"]),
+	_enddr((Jtag::tapState_t)fsm_state["IDLE"]), _endir((Jtag::tapState_t)fsm_state["IDLE"]),
 	_run_state(fsm_state["IDLE"]), _end_state(fsm_state["IDLE"])
 
 {

--- a/src/svf_jtag.hpp
+++ b/src/svf_jtag.hpp
@@ -58,8 +58,8 @@ class SVF_jtag {
 	bool _verbose;
 
 	uint32_t _freq_hz;
-	int _enddr;
-	int _endir;
+	Jtag::tapState_t _enddr;
+	Jtag::tapState_t _endir;
 	int _run_state;
 	int _end_state;
 	svf_XYR hdr;

--- a/src/svf_jtag.hpp
+++ b/src/svf_jtag.hpp
@@ -60,8 +60,8 @@ class SVF_jtag {
 	uint32_t _freq_hz;
 	Jtag::tapState_t _enddr;
 	Jtag::tapState_t _endir;
-	int _run_state;
-	int _end_state;
+	Jtag::tapState_t _run_state;
+	Jtag::tapState_t _end_state;
 	svf_XYR hdr;
 	svf_XYR hir;
 	svf_XYR sdr;

--- a/src/usbBlaster.cpp
+++ b/src/usbBlaster.cpp
@@ -89,7 +89,7 @@ uint32_t UsbBlaster::getClkFreq()
 	return ll_driver->getClkFreq();
 }
 
-int UsbBlaster::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
+int UsbBlaster::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer)
 {
 	int ret;
 
@@ -138,14 +138,14 @@ int UsbBlaster::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
 
 #include "configBitstreamParser.hpp"
 
-int UsbBlaster::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
+int UsbBlaster::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 {
 	uint32_t real_len = (end) ? len -1 : len;
 	uint32_t nb_byte = real_len >> 3;
 	uint32_t nb_bit = (real_len & 0x07);
 	uint8_t mode = (rx != NULL)? DO_RDWR : DO_WRITE;
 
-	uint8_t *tx_ptr = tx;
+	const uint8_t *tx_ptr = tx;
 	uint8_t *rx_ptr = rx;
 
 	/* security: send residual
@@ -349,8 +349,8 @@ UsbBlasterI::UsbBlasterI()
 		throw std::exception();
 	}
 
-     ret = ftdi_usb_open(_ftdi, 0x09fb, 0x6001);
-    if (ret < 0) {
+	 ret = ftdi_usb_open(_ftdi, 0x09fb, 0x6001);
+	if (ret < 0) {
 		fprintf(stderr, "unable to open ftdi device: %d (%s)\n",
 			ret, ftdi_get_error_string(_ftdi));
 		ftdi_free(_ftdi);

--- a/src/usbBlaster.hpp
+++ b/src/usbBlaster.hpp
@@ -54,10 +54,10 @@ class UsbBlaster : public JtagInterface {
 	 * \param flush_buffer force flushing the buffer
 	 * \return number of state written
 	 * */
-	int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) override;
+	int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) override;
 
 	/* TDI */
-	int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+	int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 	/*!
 	 * \brief toggle clock with static tms and tdi
 	 * \param tms TMS state

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -330,7 +330,7 @@ void Xilinx::reset()
 	_jtag->toggleClk(2000);
 }
 
-int Xilinx::idCode()
+uint32_t Xilinx::idCode()
 {
 	int id = 0;
 	unsigned char tx_data[4]= {0x00, 0x00, 0x00, 0x00};

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -508,7 +508,7 @@ bool Xilinx::load_bridge()
 void Xilinx::program_spi(ConfigBitstreamParser * bit, unsigned int offset,
 		bool unprotect_flash)
 {
-	uint8_t *data = bit->getData();
+	const uint8_t *data = bit->getData();
 	int length = bit->getLength() / 8;
 	SPIInterface::write(offset, data, length, unprotect_flash);
 }
@@ -570,7 +570,7 @@ void Xilinx::program_mem(ConfigBitstreamParser *bitfile)
 	 */
 	/* GGM: TODO */
 	int byte_length = bitfile->getLength() / 8;
-	uint8_t *data = bitfile->getData();
+	const uint8_t *data = bitfile->getData();
 	int tx_len, tx_end;
 	int burst_len = byte_length / 100;
 
@@ -585,9 +585,9 @@ void Xilinx::program_mem(ConfigBitstreamParser *bitfile)
 			tx_end = Jtag::UPDATE_DR;
 		} else {
 			tx_len = burst_len * 8;
-	        /*
-	         * 12: Enter the SHIFT-DR state.              X     0   2
-	         */
+			/*
+			 * 12: Enter the SHIFT-DR state.              X     0   2
+			 */
 			tx_end = Jtag::SHIFT_DR;
 		}
 		_jtag->shiftDR(data+i, NULL, tx_len, tx_end);
@@ -727,7 +727,7 @@ bool Xilinx::xc3s_flow_program(ConfigBitstreamParser *bit)
 {
 	int byte_length = bit->getLength() / 8;
 	int burst_len = byte_length / 100;
-	uint8_t *data = bit->getData();
+	const uint8_t *data = bit->getData();
 	int tx_len = burst_len * 8, tx_end = Jtag::SHIFT_DR;
 	ProgressBar progress("Flash SRAM", byte_length, 50, _quiet);
 
@@ -769,8 +769,9 @@ bool Xilinx::xc3s_flow_program(ConfigBitstreamParser *bit)
 	_jtag->toggleClk(32);
 	if (_jtag->shiftIR(BYPASS, _irlen) < 0)
 		return false;
-	data[0] = 0x00;
-	if (_jtag->shiftDR(data, NULL, 1) < 0)
+	//data[0] = 0x00;
+	uint8_t d = 0;
+	if (_jtag->shiftDR(&d, NULL, 1) < 0)
 		return false;
 	_jtag->toggleClk(1);
 
@@ -1076,7 +1077,7 @@ bool Xilinx::xcf_program(ConfigBitstreamParser *bitfile)
 	uint8_t tx_buf[4096 / 8];
 	uint16_t pkt_len =
 		((_jtag->get_target_device_id() == 0x05044093) ? 2048 : 4096) / 8;
-	uint8_t *data = bitfile->getData();
+	const uint8_t *data = bitfile->getData();
 	uint32_t data_len = bitfile->getLength() / 8;
 	uint32_t xfer_len, offset = 0;
 	uint32_t addr = 0;
@@ -1520,7 +1521,7 @@ bool Xilinx::xc2c_flow_program(JedParser *jed)
  *        so to send only a cmd set len to 0 (or omit this param)
  */
 int Xilinx::spi_put(uint8_t cmd,
-			uint8_t *tx, uint8_t *rx, uint32_t len)
+			const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int xfer_len = len + 1 + ((rx == NULL) ? 0 : 1);
 	uint8_t jtx[xfer_len];
@@ -1546,7 +1547,7 @@ int Xilinx::spi_put(uint8_t cmd,
 	return 0;
 }
 
-int Xilinx::spi_put(uint8_t *tx, uint8_t *rx, uint32_t len)
+int Xilinx::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int xfer_len = len + ((rx == NULL) ? 0 : 1);
 	uint8_t jtx[xfer_len];

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -571,7 +571,8 @@ void Xilinx::program_mem(ConfigBitstreamParser *bitfile)
 	/* GGM: TODO */
 	int byte_length = bitfile->getLength() / 8;
 	const uint8_t *data = bitfile->getData();
-	int tx_len, tx_end;
+	int tx_len;
+	Jtag::tapState_t tx_end;
 	int burst_len = byte_length / 100;
 
 	ProgressBar progress("Flash SRAM", byte_length, 50, _quiet);
@@ -728,7 +729,8 @@ bool Xilinx::xc3s_flow_program(ConfigBitstreamParser *bit)
 	int byte_length = bit->getLength() / 8;
 	int burst_len = byte_length / 100;
 	const uint8_t *data = bit->getData();
-	int tx_len = burst_len * 8, tx_end = Jtag::SHIFT_DR;
+	int tx_len = burst_len * 8;
+	Jtag::tapState_t tx_end = Jtag::SHIFT_DR;
 	ProgressBar progress("Flash SRAM", byte_length, 50, _quiet);
 
 	flow_enable();
@@ -1081,7 +1083,7 @@ bool Xilinx::xcf_program(ConfigBitstreamParser *bitfile)
 	uint32_t data_len = bitfile->getLength() / 8;
 	uint32_t xfer_len, offset = 0;
 	uint32_t addr = 0;
-	int xfer_end;
+	Jtag::tapState_t xfer_end;
 
 	/* limit JTAG clock frequency to 15MHz */
 	if (_jtag->getClkFreq() > 15e6)

--- a/src/xilinx.hpp
+++ b/src/xilinx.hpp
@@ -134,9 +134,9 @@ class Xilinx: public Device, SPIInterface {
 		bool xc2c_flow_program(JedParser *jed);
 
 		/* spi interface */
-		int spi_put(uint8_t cmd, uint8_t *tx, uint8_t *rx,
+		int spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 				uint32_t len) override;
-		int spi_put(uint8_t *tx, uint8_t *rx, uint32_t len) override;
+		int spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len) override;
 		int spi_wait(uint8_t cmd, uint8_t mask, uint8_t cond,
 				uint32_t timeout, bool verbose = false) override;
 

--- a/src/xilinx.hpp
+++ b/src/xilinx.hpp
@@ -46,7 +46,7 @@ class Xilinx: public Device, SPIInterface {
 		 */
 		bool bulk_erase_flash() override;
 
-		int idCode() override;
+		uint32_t idCode() override;
 		void reset() override;
 
 		/* -------------- */

--- a/src/xilinxMapParser.cpp
+++ b/src/xilinxMapParser.cpp
@@ -42,7 +42,7 @@ int XilinxMapParser::parse()
 
 	while(std::getline(ss, line, '\n')) {
 		bool empty = true;  // to said if line contains only '\t' (empty)
-		                    // or one or more blank in a non empty line
+							// or one or more blank in a non empty line
 		size_t prev_pos = 0, next_pos;
 		int row = 0;
 		/* suppress potential '\r' (thanks windows) */

--- a/src/xvc_client.cpp
+++ b/src/xvc_client.cpp
@@ -43,8 +43,8 @@ XVC_client::XVC_client(const std::string &ip_addr, int port,
 	std::regex r("[_:]");
 	string rep((const char *)buffer);
 
-    std::sregex_token_iterator start{ rep.begin(), rep.end(), r, -1 }, end;
-    std::vector<std::string> toto(start, end);
+	std::sregex_token_iterator start{ rep.begin(), rep.end(), r, -1 }, end;
+	std::vector<std::string> toto(start, end);
 
 	if (toto.size() != 3)
 		throw std::runtime_error("wrong getinfo: answer");
@@ -87,7 +87,7 @@ XVC_client::~XVC_client()
 	close(_sock);
 }
 
-int XVC_client::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
+int XVC_client::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer)
 {
 	// empty buffer
 	// if asked flush
@@ -121,7 +121,7 @@ int XVC_client::writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer)
 	return len;
 }
 
-int XVC_client::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
+int XVC_client::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 {
 	if (len == 0)  // nothing to do
 		return 0;
@@ -130,7 +130,8 @@ int XVC_client::writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 
 	uint32_t xfer_len = _buffer_size * 8;  // default to buffer capacity
 	uint8_t tms = (_last_tms) ? 0xff : 0x00;  // set tms byte
-	uint8_t *tx_ptr = tx, *rx_ptr = rx;  // use pointer to simplify algo
+	const uint8_t *tx_ptr = tx;
+	uint8_t *rx_ptr = rx;  // use pointer to simplify algo
 
 	/* write by burst */
 	for (uint32_t rest = 0; rest < len; rest += xfer_len) {

--- a/src/xvc_client.hpp
+++ b/src/xvc_client.hpp
@@ -43,7 +43,7 @@ class XVC_client: public JtagInterface {
 		 * \param[in] flush_buffer: force buffer to be send or not
 		 * \return <= 0 if something wrong, len otherwise
 		 */
-		int writeTMS(uint8_t *tms, uint32_t len, bool flush_buffer) override;
+		int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer) override;
 
 		/*!
 		 * \brief write and read len bits with optional tms set to 1 if end
@@ -53,7 +53,7 @@ class XVC_client: public JtagInterface {
 		 * \param[in] end: if true tms is set to one with the last tdi bit
 		 * \return <= 0 if something wrong, len otherwise
 		 */
-		int writeTDI(uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+		int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 
 		/*!
 		 * \brief send a serie of clock cycle with constant TMS and TDI


### PR DESCRIPTION
Replace std::string for data buffer with the std::vector<uint8_t> as more suitable
Make pointers to its data const so not to screw container itself
Use JTAG state enum instead of integer to better convey sense to compiler
IDCODE is a hex number, so there is no profit in having it signed