### PR TITLE
Adding xcku115 to parts list

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -228,6 +228,7 @@ Xilinx:
     Model:
       - xcku035
       - xcku040
+      - xcku115
     URL: https://www.xilinx.com/products/silicon-devices/fpga/kintex-ultrascale.html#productTable
     Memory: OK
     Flash: NA

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -87,6 +87,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	/* Xilinx Ultrascale / Kintex */
 	{0x13822093, {"xilinx", "kintexus", "xcku040", 6}},
 	{0x13823093, {"xilinx", "kintexus", "xcku035", 6}},
+ 	{0x1390d093, {"xilinx", "kintexus", "xcku115", 6}},
 
 	/* Xilinx Ultrascale+ / Artix */
 	{0x04A64093, {"xilinx", "artixusp", "xcau25p", 6}},


### PR DESCRIPTION
This is the device ID specifically for the FPGA we have on our board. The full part number of our FPGA is `XCKU115-2FLVB2104E`