### PR TITLE
ALINX AX7102 board.

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -41,6 +41,13 @@
   Memory: OK
   Flash: OK
 
+- ID: alinx_ax7102
+  Description: ALINX AX/7102
+  URL: https://alinx.com/en/detail/493
+  FPGA: Artix xc7a100tfgg484
+  Memory: OK
+  Flash: OK
+
 - ID: analogMax
   Description: Trenz TEI0010 - AnalogMax
   URL: https://wiki.trenz-electronic.de/display/PD/TEI0010+-+AnalogMax

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -109,6 +109,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("alchitry_au",     "xc7a35tftg256",  "ft2232",   0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("alchitry_au_plus","xc7a100tftg256",  "ft2232",   0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("alinx_ax516",     "xc6slx16csg324", "",         0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("alinx_ax7102",    "xc7a100tfgg484", "",         0, 0, CABLE_DEFAULT),
 	/* left for backward compatibility, use right name instead */
 	JTAG_BOARD("arty",            "xc7a35tcsg324",  "digilent", 0, 0, CABLE_MHZ(10)),
 	JTAG_BOARD("arty_a7_35t",     "xc7a35tcsg324",  "digilent", 0, 0, CABLE_MHZ(10)),


### PR DESCRIPTION
I'd like to report success in programming an ALINX AX7102 Artix-7 FPGA Development Board.

Programming just worked out of the box! Thanks!

./openFPGALoader -v -v -c ft232 someproj.bit

gives the following output:

```
found 1 devices
index 0:
	idcode 0x3631093
	manufacturer xilinx
	family artix a7 100t
	model  xc7a100
	irlength 6
```

I am programming it with an ALINX AL321 USB cable. 
Since it is external, I did not specify ft232 it in board.hpp.
However ALINX seems to ship one such cable with each board, so perhaps would make sense to specify it as a default cable?

Writing to flash also works (now with -b alinx_ax7102), and tells:

Detected: micron N25Q128_3V 256 sectors size: 128Mb