### PR TITLE
ALINX AX7101 board.

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -41,6 +41,13 @@
   Memory: OK
   Flash: OK
 
+- ID: alinx_ax7101
+  Description: ALINX AX/7101
+  URL: https://alinx.com/en/detail/494
+  FPGA: Artix xc7a100tfgg484
+  Memory: OK
+  Flash: OK
+
 - ID: alinx_ax7102
   Description: ALINX AX/7102
   URL: https://alinx.com/en/detail/493

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -109,6 +109,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("alchitry_au",     "xc7a35tftg256",  "ft2232",   0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("alchitry_au_plus","xc7a100tftg256",  "ft2232",   0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("alinx_ax516",     "xc6slx16csg324", "",         0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("alinx_ax7101",    "xc7a100tfgg484", "",         0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("alinx_ax7102",    "xc7a100tfgg484", "",         0, 0, CABLE_DEFAULT),
 	/* left for backward compatibility, use right name instead */
 	JTAG_BOARD("arty",            "xc7a35tcsg324",  "digilent", 0, 0, CABLE_MHZ(10)),


### PR DESCRIPTION
Uses same FPGA-board as on the carrier AX7102, so essentially same as #397.