### PR TITLE
Add xc7k70t and small fixes for xc7k160t

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -209,6 +209,7 @@ Xilinx:
 
   - Description: Kintex 7
     Model:
+      - xc7k70t
       - xc7k160t
       - xc7k325t
       - xc7k410t

--- a/spiOverJtag/Makefile
+++ b/spiOverJtag/Makefile
@@ -8,6 +8,7 @@ XILINX_PARTS := xc3s500evq100 \
 	xc7a100tcsg324 xc7a100tfgg484 xc7a100tfgg676\
 	xc7a200tsbg484 xc7a200tfbg484 \
 	xc7s25csga225 xc7s25csga324 xc7s50csga324 \
+	xc7k70tfbg676 \
 	xc7k160tffg676 \
 	xc7k325tffg676 xc7k325tffg900 \
 	xc7k420tffg901 \

--- a/spiOverJtag/build.py
+++ b/spiOverJtag/build.py
@@ -88,6 +88,7 @@ if tool in ["ise", "vivado"]:
         "xc7a100tfgg676"   : "xc7a_fgg676",
         "xc7a200tsbg484"   : "xc7a_sbg484",
         "xc7a200tfbg484"   : "xc7a_fbg484",
+        "xc7k70tfbg676"    : "xc7k_fbg676",
         "xc7k160tffg676"   : "xc7k_ffg676",
         "xc7k325tffg676"   : "xc7k_ffg676",
         "xc7k325tffg900"   : "xc7k_ffg900",

--- a/spiOverJtag/xilinx_spiOverJtag.tcl
+++ b/spiOverJtag/xilinx_spiOverJtag.tcl
@@ -16,6 +16,8 @@ set grade [dict create \
 	xc7a75tfgg484  -2 \
 	xc7a100tfgg484 -2 \
 	xc7a200tsbg484 -1 \
+	xc7k70tfbg676  -1 \
+	xc7k160tffg676 -1 \
 	xc7k325tffg676 -1 \
 	xc7k325tffg900 -2 \
 	xc7s25csga225  -1 \
@@ -33,6 +35,8 @@ set pkg_name [dict create \
 	xc7a100tfgg484 xc7a_fgg484 \
 	xc7a200tsbg484 xc7a_sbg484 \
 	xc7a200tfbg484 xc7a_fbg484 \
+	xc7k70tfbg676  xc7k_fbg676 \
+	xc7k160tffg676 xc7k_ffg676 \
 	xc7k325tffg676 xc7k_ffg676 \
 	xc7k325tffg900 xc7k_ffg900 \
 	xc7s25csga225  xc7s_csga225 \

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -73,6 +73,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	{0x03636093, {"xilinx", "artix a7 200t", "xc7a200", 6}},
 
 	/* Xilinx 7-Series / Kintex7 */
+	{0x03647093, {"xilinx", "kintex7", "xc7k70t",  6}},
 	{0x0364c093, {"xilinx", "kintex7", "xc7k160t", 6}},
 	{0x03651093, {"xilinx", "kintex7", "xc7k325t", 6}},
 	{0x03656093, {"xilinx", "kintex7", "xc7k410t", 6}},


### PR DESCRIPTION
I just got this very affordable Kintex 70T board:
https://www.aliexpress.com/item/1005005572549665.html
I did not try spi over JTAG yet.
the default cmake / make / make install did not build it.
I also saw there were some entries missing for the 160t for consistency.

Let me know, what you think.