### PR TITLE
Add user device list for non-fpga JTAG devices

### DIFF
--- a/src/jtag.cpp
+++ b/src/jtag.cpp
@@ -77,11 +77,13 @@ Jtag::Jtag(const cable_t &cable, const jtag_pins_conf_t *pin_conf,
 			const string &dev,
 			const string &serial, uint32_t clkHZ, int8_t verbose,
 			const string &ip_adr, int port,
-			const bool invert_read_edge, const string &firmware_path):
+			const bool invert_read_edge, const string &firmware_path,
+			const std::map<uint32_t, misc_device> &user_misc_devs):
 			_verbose(verbose > 1),
 			_state(RUN_TEST_IDLE),
 			_tms_buffer_size(128), _num_tms(0),
-			_board_name("nope"), device_index(0), _curr_tdi(1)
+			_board_name("nope"), device_index(0), _curr_tdi(1),
+			_user_misc_devs(user_misc_devs)
 {
 	switch (cable.type) {
 	case MODE_ANLOGICCABLE:
@@ -244,6 +246,11 @@ bool Jtag::search_and_insert_device_with_idcode(uint32_t idcode)
 	if (irlength == -1) {
 		auto misc = misc_dev_list.find(idcode);
 		if (misc != misc_dev_list.end())
+			irlength = misc->second.irlength;
+	}
+	if (irlength == -1) {
+		auto misc = this->_user_misc_devs.find(idcode);
+		if (misc != this->_user_misc_devs.end())
 			irlength = misc->second.irlength;
 	}
 	if (irlength == -1)

--- a/src/jtag.hpp
+++ b/src/jtag.hpp
@@ -12,6 +12,7 @@
 
 #include "board.hpp"
 #include "cable.hpp"
+#include "part.hpp"
 #include "jtagInterface.hpp"
 
 class Jtag {
@@ -21,7 +22,8 @@ class Jtag {
 		const std::string &serial, uint32_t clkHZ, int8_t verbose,
 		const std::string &ip_adr, int port,
 		const bool invert_read_edge = false,
-		const std::string &firmware_path = "");
+		const std::string &firmware_path = "",
+		const std::map<uint32_t, misc_device> &user_misc_devs = {});
 	~Jtag();
 
 	/* maybe to update */
@@ -146,6 +148,7 @@ class Jtag {
 	int _num_tms;
 	unsigned char *_tms_buffer;
 	std::string _board_name;
+	const std::map<uint32_t, misc_device>& _user_misc_devs;
 
 	int device_index; /*!< index for targeted FPGA */
 


### PR DESCRIPTION
This allows a user with other arbitrary devices on the bus to pass it on the command line rather than require parts.hpp to be aware of all jtag devices.  Eg, if a bus has multiple devices on the chain:
```
./openFPGALoader \
    --cable jlink_base \
    --detect
device type: J-Link major: 10 minor: 10 revision: 0
JTAG init failed with: Unknown device with IDCODE: 0x00c0ffee (manufacturer: 0x001 (), part: 0x10 vers: 0x0

./openFPGALoader \
    --cable jlink_base \
    --detect \
    --misc-device "0xc0ffee,14,Coffee Maker"
device type: J-Link major: 10 minor: 10 revision: 0
index 0:
	idcode 0x31820dd
	manufacturer altera
	family MAX 10
	model  10M08SAU169C8G
	irlength 10
index 1:
	idcode   0x00c0ffee
	type     Coffee Maker
	irlength 14
```