### PR TITLE
gatemate: fix configuration byte alignment in jtag chains

### DIFF
--- a/src/colognechip.cpp
+++ b/src/colognechip.cpp
@@ -7,6 +7,7 @@
 #include "colognechip.hpp"
 
 #include <memory>
+#include <string.h>
 
 #define JTAG_CONFIGURE  0x06
 #define JTAG_SPI_BYPASS 0x05
@@ -278,6 +279,25 @@ void CologneChip::programJTAG_sram(const uint8_t *data, int length)
 	_jtag->shiftIR(JTAG_CONFIGURE, 6, Jtag::SELECT_DR_SCAN);
 
 	ProgressBar progress("Load SRAM via JTAG", length, 50, _quiet);
+
+	/* make sure to only send multiples of 8 bits */
+	int bits_before = _jtag->get_devices_list().size() - _jtag->get_device_index() - 1;
+	if (bits_before > 0) {
+		int n = 8 - (bits_before % 8);
+		_jtag->toggleClk(n);
+	}
+
+	/* the bypass register defaults to '0'.
+	 * in order to generate a proper 'nop' command (0x00, 0xFF), send a
+	 * sequence of zeros instead of ones.
+	 */
+	int bits_after = _jtag->get_device_index();
+	if (bits_after > 0) {
+		int n = (bits_after + 7) / 8;
+		uint8_t tx[n];
+		memset(tx, 0x00, n);
+		_jtag->shiftDR(tx, NULL, 8-bits_after, Jtag::SHIFT_DR);
+	}
 
 	for (int i = 0; i < length; i += size) {
 		if (length < i + size)

--- a/src/jtag.hpp
+++ b/src/jtag.hpp
@@ -66,6 +66,12 @@ class Jtag {
 	std::vector<int> get_devices_list() {return _devices_list;}
 
 	/*!
+	 * \brief return device index in list
+	 * \return device index
+	 */
+	int get_device_index() {return device_index;}
+
+	/*!
 	 * \brief return current selected device idcode
 	 * \return device idcode
 	 */


### PR DESCRIPTION
When used in a JTAG chain with multiple devices - and due to the additional bypass cycles - the 8-bit words in the DR register are not always contiguous. This PR sends the corresponding sequence of zeros so that there are always correct multiples of 8.

This allows configuration of individual GateMate FPGAs in a chain (using --index-chain).