### PR TITLE
Add faulty MPSEE cmd 8E workaround

### DIFF
--- a/src/ftdiJtagMPSSE.hpp
+++ b/src/ftdiJtagMPSSE.hpp
@@ -106,6 +106,7 @@ class FtdiJtagMPSSE : public JtagInterface, public FTDIpp_MPSSE {
 	 */
 	void config_edge();
 	bool _ch552WA; /* avoid errors with SiPeed tangNano */
+	bool _cmd8EWA; /* avoid errors with Sipeed FT2232H emulation */
 	uint8_t _write_mode; /**< write edge configuration */
 	uint8_t _read_mode; /**< read edge configuration */
 	bool _invert_read_edge; /**< read edge selection (false: pos, true: neg) */

--- a/src/ftdipp_mpsse.cpp
+++ b/src/ftdipp_mpsse.cpp
@@ -91,6 +91,32 @@ FTDIpp_MPSSE::FTDIpp_MPSSE(const cable_t &cable, const string &dev,
 		printWarn(err);
 		memset(_iproduct,'\0', 200);
 	}
+
+	ret = (libusb_error)libusb_get_string_descriptor_ascii(_ftdi->usb_dev,
+		usb_desc.iManufacturer, _imanufacturer, 200);
+	/* when FTDI device has no iManufacturer, libusb returns an error
+	 * but there is no distinction between real error and empty field
+	 */
+	if (ret < 0) {
+		snprintf(err, sizeof(err),
+			"Can't read iManufacturer field from FTDI: "
+			"considered as empty string");
+		printWarn(err);
+		memset(_imanufacturer,'\0', 200);
+	}
+
+	ret = (libusb_error)libusb_get_string_descriptor_ascii(_ftdi->usb_dev,
+		usb_desc.iSerialNumber, _iserialnumber, 200);
+	/* when FTDI device has no iSerialNumber, libusb returns an error
+	 * but there is no distinction between real error and empty field
+	 */
+	if (ret < 0) {
+		snprintf(err, sizeof(err),
+			"Can't read iSerialNumber field from FTDI: "
+			"considered as empty string");
+		printWarn(err);
+		memset(_iserialnumber,'\0', 200);
+	}
 }
 
 FTDIpp_MPSSE::~FTDIpp_MPSSE()

--- a/src/ftdipp_mpsse.hpp
+++ b/src/ftdipp_mpsse.hpp
@@ -81,6 +81,8 @@ class FTDIpp_MPSSE {
 		int _num;
 		unsigned char *_buffer;
 		uint8_t _iproduct[200];
+		uint8_t _imanufacturer[200];
+		uint8_t _iserialnumber[200];
 };
 
 #endif


### PR DESCRIPTION
Fixes #421

Activates workaround to avoid MPSEE commands 0x8E and 0x8F when Sipeed device with serial number 2023112818 is detected.