### PR TITLE
spiFlashdb: add MX25R6435F and fix SPIFlash::bp_to_len

### DIFF
--- a/src/spiFlash.cpp
+++ b/src/spiFlash.cpp
@@ -895,6 +895,9 @@ std::map<std::string, uint32_t> SPIFlash::bp_to_len(uint8_t bp, uint8_t tb)
 	for (int i = 0; i < 4; i++)
 		if ((bp & _flash_model->bp_offset[i]))
 			tmp |= (1 << i);
+	/* 0 -> no block protected */
+	if (tmp == 0)
+		return protect_area;
 	/* bp code is 2^(bp-1) blocks */
 	uint16_t nr_sectors = (1 << (tmp-1));
 	printf("nr_sectors : %d\n", nr_sectors);

--- a/src/spiFlashdb.hpp
+++ b/src/spiFlashdb.hpp
@@ -354,6 +354,20 @@ static std::map <uint32_t, flash_t> flash_list = {
 		.bp_len = 5,
 		.bp_offset = {(1 << 2), (1 << 3), (1 << 4), (1 << 5)}}
 	},
+	{0xc22817, {
+	/* https://www.macronix.com/Lists/Datasheet/Attachments/8868/MX25R6435F,%20Wide%20Range,%2064Mb,%20v1.6.pdf */
+		.manufacturer = "Macronix",
+		.model = "MX25R6435F",
+		.nr_sector = 128,
+		.sector_erase = true,
+		.subsector_erase = true,
+		.has_extended = false,
+		.tb_otp = true,
+		.tb_offset = (1 << 3),
+		.tb_register = CONFR,
+		.bp_len = 4,
+		.bp_offset = {(1 << 2), (1 << 3), (1 << 4), 0}}
+	},
 	{0xef4014, {
 	/* https://cdn-shop.adafruit.com/datasheets/W25Q80BV.pdf */
 		.manufacturer = "Winbond",


### PR DESCRIPTION
This device was missing in spiFlashdb and is installed on the GateMate evaluation board.

MX25R6435F's status register contains a quad-enable bit.
![image](https://github.com/trabucayre/openFPGALoader/assets/14027986/2acb94b6-2f48-4451-b3a3-6e3bafe280ae)


If it is set, `SPIFlash::bp_to_len` incorrectly masks all sectors, even if no bp-bit is set. This fix seems obvious to me, but I don't have many boards to test this.