### PR TITLE
Add support for the Cyclone II

### DIFF
--- a/src/part.hpp
+++ b/src/part.hpp
@@ -164,7 +164,8 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	/*                             Altera                                     */
 	/**************************************************************************/
 
-	/* Altera Cyclone III/IV/10 LP */
+	/* Altera Cyclone II/III/IV/10 LP */
+        {0x020b10dd, {"altera", "cyclone II", "EP2C5", 10}},
 	{0x020f20dd, {"altera", "cyclone III/IV/10 LP", "EP3C16/EP4CE15/10CL016",   10}},
 	{0x020f70dd, {"altera", "cyclone III/IV/10 LP", "EP3C120/EP4CE115/10CL120", 10}},
 


### PR DESCRIPTION
Add support for the Cyclone II board. **TESTED with RAM**
**NOTES**:
 * Known to work with SVF files

**TODO**:
 * Debug RBF files
 * Debug FLASH load using secondary JTAG header on the board
 
