### PR TITLE
Add EP4CGX150

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -79,6 +79,13 @@ Intel:
     Memory: OK
     Flash: OK
 
+  - Description: Cyclone IV GX
+    Model:
+      - EP4CGX150
+    URL: https://www.intel.com/content/www/us/en/products/details/fpga/cyclone/iv/gx/products.html
+    Memory: OK
+    Flash: OK
+
   - Description: Cyclone V E
     Model:
       - 5CEA2

--- a/spiOverJtag/Makefile
+++ b/spiOverJtag/Makefile
@@ -21,7 +21,7 @@ XILINX_PARTS := xc3s500evq100 \
 XILINX_BIT_FILES := $(addsuffix .bit.gz,$(addprefix spiOverJtag_, $(XILINX_PARTS)))
 
 ALTERA_PARTS := 10cl025256 10cl016484 10cl055484 \
-	ep4ce2217 ep4ce1523 ep4ce11523 5ce223 5ce423 5ce523 5ce927
+	ep4ce2217 ep4ce1523 ep4ce11523 ep4cgx15027 5ce223 5ce423 5ce523 5ce927
 ALTERA_BIT_FILES := $(addsuffix .rbf.gz, $(addprefix spiOverJtag_, $(ALTERA_PARTS)))
 
 BIT_FILES := $(ALTERA_BIT_FILES) $(XILINX_BIT_FILES)

--- a/spiOverJtag/build.py
+++ b/spiOverJtag/build.py
@@ -172,18 +172,19 @@ if tool in ["ise", "vivado"]:
     files.append({'name': cst_file, 'file_type': cst_type})
 else:
     full_part = {
-        "10cl016484": "10CL016YU484C8G",
-        "10cl025256": "10CL025YU256C8G",
-        "10cl055484": "10CL055YU484C8G",
-        "ep4ce11523": "EP4CE115F23C7",
-        "ep4ce2217" : "EP4CE22F17C6",
-        "ep4ce1523" : "EP4CE15F23C8",
-        "5ce223"    : "5CEFA2F23I7",
-        "5ce523"    : "5CEFA5F23I7",
-        "5ce423"    : "5CEBA4F23C8",
-        "5ce927"    : "5CEBA9F27C7",
-        "5cse423"   : "5CSEMA4U23C6",
-        "5cse623"   : "5CSEBA6U23I7"}[part]
+        "10cl016484" : "10CL016YU484C8G",
+        "10cl025256" : "10CL025YU256C8G",
+        "10cl055484" : "10CL055YU484C8G",
+        "ep4cgx15027": "EP4CGX150DF27I7",
+        "ep4ce11523" : "EP4CE115F23C7",
+        "ep4ce2217"  : "EP4CE22F17C6",
+        "ep4ce1523"  : "EP4CE15F23C8",
+        "5ce223"     : "5CEFA2F23I7",
+        "5ce523"     : "5CEFA5F23I7",
+        "5ce423"     : "5CEBA4F23C8",
+        "5ce927"     : "5CEBA9F27C7",
+        "5cse423"    : "5CSEMA4U23C6",
+        "5cse623"    : "5CSEBA6U23I7"}[part]
     files.append({'name': currDir + 'altera_spiOverJtag.v',
                   'file_type': 'verilogSource'})
     files.append({'name': currDir + 'altera_spiOverJtag.sdc',

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -194,6 +194,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("pynq_z1",         "xc7z020clg400",  "ft2232", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("pynq_z2",         "xc7z020clg400",  "ft2232", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("qmtechCyclone10", "10cl016484", "",  0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("qmtechCycloneIVGX", "ep4cgx15027", "",  0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("qmtechCycloneIV", "ep4ce1523", "",  0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("qmtechCycloneV",  "5ce223", "",     0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("qmtechCycloneV_5ce523",  "5ce523", "",	0,0, CABLE_DEFAULT),

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -170,6 +170,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
         {0x020b10dd, {"altera", "cyclone II", "EP2C5", 10}},
 	{0x020f20dd, {"altera", "cyclone III/IV/10 LP", "EP3C16/EP4CE15/10CL016",   10}},
 	{0x020f70dd, {"altera", "cyclone III/IV/10 LP", "EP3C120/EP4CE115/10CL120", 10}},
+	{0x028040dd, {"altera", "cyclone IV GX", "EP4CGX150", 10}},
 
 	/* Altera Cyclone V */
 	{0x02b010dd, {"altera", "cyclone V",     "5CGX*3",                10}},


### PR DESCRIPTION
I could not test flash, because I am not sure of how to build a bistream for it.
I tried `./build.py ep4cgx15027`, but it errors.
when I cd into the tmp directory of it and run make manually I get the following error:
```
...
Error (12006): Node instance "altclkctrl_component" instantiates undefined entity "altclkctrl_inst". Ensure that required library paths are specified correctly, define the specified entity, or change the instantiation. If this entity represents Intel FPGA or third-party IP, generate the synthesis files for the IP. File: /opt/intelFPGA_lite/22.1/quartus/libraries/megafunctions/alt_sfl_enhanced.v Line: 200
...
```
When I try to build the bistream for EP4CE15 I get the same error,
so I am not sure if that error is my fault.

Loading a bitstream into memory works.