### PR TITLE
Adding support for Xilinx Virtex 7 FPGA VC709 Connectivity Kit Board

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -846,6 +846,13 @@
   Memory: OK
   Flash: OK
 
+- ID: vc709
+  Description: AMD Virtex-7 FPGA VC709 Connectivity Kit
+  URL: https://www.xilinx.com/products/boards-and-kits/dk-v7-vc709-g.html
+  FPGA: Virtex7 xc7vx690tffg1761
+  Memory: OK
+  Flash: NA
+
 - ID: vcu118
   Description: Xilinx VCU118
   URL: https://www.xilinx.com/products/boards-and-kits/vcu118.html

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -233,6 +233,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("usrpx300",        "xc7k325tffg900", "digilent", 0, 0, CABLE_MHZ(15)),
 	JTAG_BOARD("usrpx310",        "xc7k410tffg900", "digilent", 0, 0, CABLE_MHZ(15)),
 	JTAG_BOARD("vec_v6",          "xc6vlx130tff784", "ft2232", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("vc709", 		  "xc7vx690tffg1761", "digilent", 0, 0, CABLE_MHZ(15)),
 	JTAG_BOARD("vcu118",          "xcvu9p-flga2104", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("vcu128",          "xcvu37p-fsvh2892", "ft4232", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("vcu1525",         "xcvu9p-fsgd2104",  "ft4232", 0, 0, CABLE_MHZ(15)),

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -84,8 +84,9 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	{0x03656093, {"xilinx", "kintex7", "xc7k410t", 6}},
 	{0x23752093, {"xilinx", "kintex7", "xc7k420t", 6}},
 
-	/* Xilinx XC7V */
+	/* Xilinx 7-Series / Virtex7 */
 	{0x03667093, {"xilinx", "virtex7", "xc7vx330t",  6}},
+	{0x33691093, {"xilinx", "virtex7", "xc7vx690t",  6}},
 
 	/* Xilinx 7-Series / Zynq */
 	{0x03722093, {"xilinx", "zynq",     "xc7z010", 6}},


### PR DESCRIPTION
This Pull request adds support for AMD Virtex 7 FPGA VC709 Connectivity Kit.
![Detect flag output](https://github.com/user-attachments/assets/975a7821-6536-4759-94db-af8d2d5e22e9)
![Load output to FPGA](https://github.com/user-attachments/assets/80e99e28-09d6-4233-9422-8a4b286237c4)