### PR TITLE
Add xc2c64a QFN48

### DIFF
--- a/src/part.hpp
+++ b/src/part.hpp
@@ -39,6 +39,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	{0x05046093, {"xilinx", "xcf",      "xcf04s",    8}},
 
 	/* Xilinx XC2 */
+	{0x06e59093, {"xilinx", "xc2c",     "xc2c64a",   8}},
 	{0x06e5d093, {"xilinx", "xc2c",     "xc2c64a",   8}},
 	{0x06e5e093, {"xilinx", "xc2c",     "xc2c64a",   8}},
 	{0x06e1c093, {"xilinx", "xc2c",     "xc2c32a",   8}},


### PR DESCRIPTION
Added ID for XC2C64A QFN48 chip.