### PR TITLE
Update Max II and Cyclone II documentation

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -69,6 +69,18 @@ Gowin:
 
 Intel:
 
+  - Description: Max II(CPLD)
+    Model: EPM240T100C5N
+    URL: https://www.intel.com/content/www/us/en/support/programmable/support-resources/devices/max-ii-support.html
+    Memory: OK
+    Flash: OK
+
+  - Description: Cyclone II
+    Model: EP2C5T144C8N
+    URL: https://www.intel.com/content/www/us/en/support/programmable/support-resources/devices/cyclone-ii-support.html
+    Memory: OK
+    Flash: OK
+    
   - Description: Cyclone III
     Model: EP3C16
     URL: https://www.intel.com/content/www/us/en/programmable/products/fpga/cyclone-series/cyclone-iii/support.html

--- a/doc/vendors/intel.rst
+++ b/doc/vendors/intel.rst
@@ -81,3 +81,28 @@ file load:
     openFPGALoader -b boardname -r project_name.rbf
 
 with ``boardname`` = ``cyc1000``, ``c10lp-refkit``.
+
+
+
+
+Intel/Altera (Old Boards)
+=========================
+
+.. NOTE::
+
+  * Cyclone II (FPGA) (Tested OK: EP2C5T144C8N)
+  * Max II (CPLD) (Tested OK: EPM240T100C5N)
+
+Loading a Serial Vector Format (.svf)
+-------------------------------------
+
+SVF files are supported.
+
+To load the file:
+
+ .. code-block:: bash
+
+    openFPGALoader -c usb-blaster project_name.svf
+
+ 
+ 


### PR DESCRIPTION
Add documentation for Max II and Cyclone II boards

- Included details on tested device models: EP2C5T144C8N and EPM240T100C5N