### PR TITLE
doc/guide/install.rst: instructions to install under Guix

### DIFF
--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -6,6 +6,15 @@ Installing openFPGALoader
 Linux
 =====
 
+Guix
+----------
+
+openFPGALoader is available in the default repositories:
+
+.. code-block:: bash
+
+    guix install openfpgaloader
+
 Arch Linux
 ----------
 


### PR DESCRIPTION
Open fpga loader is [available](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/fpga.scm?h=master#n609), operational and up to date in the guix standard repositories. The advantage about other package managers is that users don't need to bother about dependencies, as they get installed along with it. 