### PR TITLE
gowin: Implement User Flash programming for GW1N9

### DIFF
--- a/doc/vendors/gowin.rst
+++ b/doc/vendors/gowin.rst
@@ -62,3 +62,17 @@ It's possible to flash external SPI Flash (connected to MSPI) in bscan mode by u
 
   Gowin's FPGA may fails to be detected if **JTAGSEL_N** (pin 08 for *GW1N-4K*) is used as a GPIO.
   To recover you have to pull down this pin (before power up) to recover JTAG interface (*UG292 - JTAGSELL_N section*).
+
+User Flash
+----------
+
+.. ATTENTION::
+  User Flash support is based on reverse engineering of the JTAG protocol. This functionality should be considered
+  experimental as it hasn't been thoroughly tested, and may in some circumstances destroy your device.
+
+Gowin FPGA come with extra flash space that can be read and written from the programmable logic ("User Flash"). This
+flash section can also be programmed via the JTAG interface:
+
+.. code-block:: bash
+
+    openFPGALoader --write-flash /path/to/bitstream.fs --user-flash /path/to/flash.bin

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -77,8 +77,8 @@ using namespace std;
 
 Gowin::Gowin(Jtag *jtag, const string filename, const string &file_type, std::string mcufw,
 		Device::prog_type_t prg_type, bool external_flash,
-		bool verify, int8_t verbose): Device(jtag, filename, file_type,
-		verify, verbose),
+		bool verify, int8_t verbose, const std::string& user_flash)
+	: Device(jtag, filename, file_type, verify, verbose),
 		SPIInterface(filename, verbose, 0, verify, false, false),
 		_idcode(0), is_gw1n1(false), is_gw1n4(false), is_gw1n9(false),
 		is_gw2a(false), is_gw5a(false),

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -80,8 +80,9 @@ Gowin::Gowin(Jtag *jtag, const string filename, const string &file_type, std::st
 		bool verify, int8_t verbose): Device(jtag, filename, file_type,
 		verify, verbose),
 		SPIInterface(filename, verbose, 0, verify, false, false),
-		_idcode(0), is_gw1n1(false), is_gw2a(false), is_gw1n4(false),
-		is_gw5a(false), _external_flash(external_flash),
+		_idcode(0), is_gw1n1(false), is_gw1n4(false), is_gw1n9(false),
+		is_gw2a(false), is_gw5a(false),
+		_external_flash(external_flash),
 		_spi_sck(BSCAN_SPI_SCK), _spi_cs(BSCAN_SPI_CS),
 		_spi_di(BSCAN_SPI_DI), _spi_do(BSCAN_SPI_DO),
 		_spi_msk(BSCAN_SPI_MSK)
@@ -168,13 +169,6 @@ bool Gowin::detectFamily()
 {
 	_idcode = _jtag->get_target_device_id();
 
-	/* erase and program flash differ for GW1N1 */
-	if (_idcode == 0x0900281B)
-		is_gw1n1 = true;
-	/* erase and program flash differ for GW1N4, GW1N1Z-1 */
-	if (_idcode == 0x0100381B || _idcode == 0x100681b)
-		is_gw1n4 = true;
-
 	/* bscan spi external flash differ for GW1NSR-4C */
 	if (_idcode == 0x0100981b) {
 		_spi_sck = BSCAN_GW1NSR_4C_SPI_SCK;
@@ -189,6 +183,16 @@ bool Gowin::detectFamily()
 	 * algorithm that is not yet supported.
 	 */
 	switch (_idcode) {
+		case 0x0900281B: /* GW1N-1 */
+			is_gw1n1 = true;
+			break;
+		case 0x0100381B: /* GW1N-4B */
+		case 0x0100681b: /* GW1NZ-1 */
+			is_gw1n4 = true;
+			break;
+		case 0x0100481B: /* GW1N(R)-9, although documentation says otherwise */
+			is_gw1n9 = true;
+			break;
 		case 0x0000081b: /* GW2A(R)-18(C) */
 		case 0x0000281b: /* GW2A(R)-55(C) */
 			_external_flash = true;

--- a/src/gowin.hpp
+++ b/src/gowin.hpp
@@ -22,7 +22,8 @@ class Gowin: public Device, SPIInterface {
 	public:
 		Gowin(Jtag *jtag, std::string filename, const std::string &file_type,
 				std::string mcufw, Device::prog_type_t prg_type,
-				bool external_flash, bool verify, int8_t verbose);
+				bool external_flash, bool verify, int8_t verbose,
+				const std::string& user_flash);
 		uint32_t idCode() override;
 		void reset() override;
 		void program(unsigned int offset, bool unprotect_flash) override;

--- a/src/gowin.hpp
+++ b/src/gowin.hpp
@@ -105,7 +105,7 @@ class Gowin: public Device, SPIInterface {
 		void programExtFlash(unsigned int offset, bool unprotect_flash);
 		void programSRAM();
 		bool writeSRAM(const uint8_t *data, int length);
-		bool writeFLASH(uint32_t page, const uint8_t *data, int length);
+		bool writeFLASH(uint32_t page, const uint8_t *data, int length, bool invert_bits = false);
 		void displayReadReg(const char *, uint32_t dev);
 		uint32_t readStatusReg();
 		uint32_t readUserCode();
@@ -131,6 +131,7 @@ class Gowin: public Device, SPIInterface {
 
 		std::unique_ptr<ConfigBitstreamParser> _fs;
 		std::unique_ptr<ConfigBitstreamParser> _mcufw;
+		std::unique_ptr<ConfigBitstreamParser> _userflash;
 		uint32_t _idcode;
 		bool is_gw1n1;
 		bool is_gw1n4;

--- a/src/gowin.hpp
+++ b/src/gowin.hpp
@@ -132,8 +132,9 @@ class Gowin: public Device, SPIInterface {
 		std::unique_ptr<ConfigBitstreamParser> _mcufw;
 		uint32_t _idcode;
 		bool is_gw1n1;
-		bool is_gw2a;
 		bool is_gw1n4;
+		bool is_gw1n9;
+		bool is_gw2a;
 		bool is_gw5a;
 		bool skip_checksum;   /**< bypass checksum verification (GW2A) */
 		bool _external_flash; /**< select between int or ext flash */

--- a/src/gowin.hpp
+++ b/src/gowin.hpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "configBitstreamParser.hpp"
 #include "device.hpp"
@@ -22,7 +23,6 @@ class Gowin: public Device, SPIInterface {
 		Gowin(Jtag *jtag, std::string filename, const std::string &file_type,
 				std::string mcufw, Device::prog_type_t prg_type,
 				bool external_flash, bool verify, int8_t verbose);
-		~Gowin();
 		uint32_t idCode() override;
 		void reset() override;
 		void program(unsigned int offset, bool unprotect_flash) override;
@@ -128,7 +128,8 @@ class Gowin: public Device, SPIInterface {
 		 */
 		bool gw5a_enable_spi();
 
-		ConfigBitstreamParser *_fs;
+		std::unique_ptr<ConfigBitstreamParser> _fs;
+		std::unique_ptr<ConfigBitstreamParser> _mcufw;
 		uint32_t _idcode;
 		bool is_gw1n1;
 		bool is_gw2a;
@@ -141,7 +142,6 @@ class Gowin: public Device, SPIInterface {
 		uint8_t _spi_di;      /**< di signal (mosi) offset in bscan SPI */
 		uint8_t _spi_do;      /**< do signal (miso) offset in bscan SPI */
 		uint8_t _spi_msk;     /** default spi msk with only do out */
-		ConfigBitstreamParser *_mcufw;
 		JtagInterface::tck_edge_t _prev_rd_edge; /**< default probe rd edge cfg */
 		JtagInterface::tck_edge_t _prev_wr_edge; /**< default probe wr edge cfg */
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,6 +97,7 @@ struct arguments {
 	bool read_dna;
 	bool read_xadc;
 	string read_register;
+	string user_flash;
 };
 
 int run_xvc_server(const struct arguments &args, const cable_t &cable,
@@ -582,7 +583,7 @@ int main(int argc, char **argv)
 				args.verify, args.verbose);
 		} else if (fab == "Gowin") {
 			fpga = new Gowin(jtag, args.bit_file, args.file_type, args.mcufw,
-				args.prg_type, args.external_flash, args.verify, args.verbose);
+				args.prg_type, args.external_flash, args.verify, args.verbose, args.user_flash);
 		} else if (fab == "lattice") {
 			fpga = new Lattice(jtag, args.bit_file, args.file_type,
 				args.prg_type, args.flash_sector, args.verify, args.verbose, args.skip_load_bridge, args.skip_reset);
@@ -871,6 +872,8 @@ int parse_opt(int argc, char **argv, struct arguments *args,
 				cxxopts::value<bool>(args->read_xadc))
 			("read-register", "Read Status Register(Xilinx FPGA only)",
 				cxxopts::value<string>(rd_reg))
+			("user-flash", "User flash file (Gowin LittleBee FPGA only)",
+				cxxopts::value<string>(args->user_flash))
 			("V,Version", "Print program version");
 
 		options.parse_positional({"bitstream"});


### PR DESCRIPTION
Hi,

Gowin FPGA with built-in flash memory offer a separate "user flash" zone ([documentation](https://cdn.gowinsemi.com.cn/UG295E.pdf)), either accessible from programmable logic, or used as system memory for the EMCU. This memory can be configured by JTAG, but this isn't documented at the moment. We've reversed how flashing was performed for the GW1N9 FPGAs by sniffing the JTAG wires: it works in the same way you flash the bitstream, but with a different base address.

This PR implements user flash programming for GW1N(R)9 FPGAs (other models probably have different base addresses). The documentation lists this addition as experimental because of the reverse engineered nature of this development. A few safeguards have been implemented to prevent misuse of this functionality (FPGA model checking, file size).

Jean