### PR TITLE
Debian/Ubuntu instructions for binary installation. Update install.rst

### DIFF
--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -6,6 +6,15 @@ Installing openFPGALoader
 Linux
 =====
 
+Debian/Ubuntu
+----------
+
+openFPGALoader is available in the default repositories:
+
+.. code-block:: bash
+    
+    sudo apt install openfpgaloader
+
 Guix
 ----------
 
@@ -42,7 +51,7 @@ openFPGALoader is available as a Copr repository:
     sudo dnf copr enable mobicarte/openFPGALoader
     sudo dnf install openFPGALoader
 
-From source (Debian, Ubuntu)
+From source 
 ----------------------------
 
 This application uses ``libftdi1``, so this library must be installed (and, depending on the distribution, headers too):


### PR DESCRIPTION
openFPGALoader binary is available in Debian/Ubuntu repositories. Added installation instructions for these distributions. New Linux users may be confused by necessity to compile the program, added installation instructions for binary packages. 