### PR TITLE
ci: add ubuntu 24

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -40,6 +40,7 @@ jobs:
         os:
         - 20
         - 22
+        - 24
     name: '🚧🐧 Ubuntu ${{ matrix.os }} | build'
     runs-on: ubuntu-${{ matrix.os }}.04
     steps:
@@ -124,6 +125,7 @@ jobs:
         os:
         - 20
         - 22
+        - 24
     name: '🚦🐧 Ubuntu ${{ matrix.os }} | test'
     runs-on: ubuntu-${{ matrix.os }}.04
     steps:


### PR DESCRIPTION
👋 [ubuntu 24 has been around for quite some time](https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/), adding it to the CI matrix.