### PR TITLE
Add Altera 10M02SCM153C8G Support.

### DIFF
--- a/src/part.hpp
+++ b/src/part.hpp
@@ -208,6 +208,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	{0x031050dd, {"altera", "MAX 10", "10M50DAF484",       10}},
 	{0x0318d0dd, {"altera", "MAX 10", "10M40SCE144C8G",    10}},
 	{0x031830dd, {"altera", "MAX 10", "10M16SAU169C8G",    10}},
+	{0x031810dd, {"altera", "MAX 10", "10M02SCM153C8G",    10}},
 
 	/* Altera Cyclone 10 */
 	{0x020f30dd, {"altera", "cyclone 10 LP", "10CL025", 10}},


### PR DESCRIPTION
Description:
STEP-MAX10 development board is equipped with Altera 10M02SCM153C8G. It is not in the support list. This PR adds this chip support. I have tested this change with my STEP-MAX10 development board. It runs as expected result. If this PR needs more inforamtion, please let me know, thanks.
![17](https://github.com/user-attachments/assets/f8a5c7a1-6d5b-4243-80ec-b987735cb0a1)


Change:
Added 'Altera 10M02SCM153C8G' in fpga_list.