### PR TITLE
Add STEP-MAX10 V1 board support.

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -136,7 +136,7 @@ Intel:
     Flash: OK
 
   - Description: Max 10
-    Model: 10M08
+    Model: 10M02, 10M08
     URL: https://www.intel.fr/content/www/fr/fr/products/details/fpga/max/10.html
     Memory: SVF
     Flash: POF

--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -995,3 +995,10 @@
   FPGA: Titanium Ti180J484 (and others)
   Memory: OK
   Flash: NA
+
+- ID: step-max10_v1
+  Description: STEP MAX10 V1
+  URL: https://wiki.stepfpga.com/step-max10
+  FPGA: Altera 10M02SCM153C8G
+  Memory: OK
+  Flash: NA

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -253,7 +253,8 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("zybo_z7_10",      "xc7z010clg400",  "digilent", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("zybo_z7_20",      "xc7z020clg400",  "digilent", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("mini_itx",        "xc7z100ffg900", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
-	JTAG_BOARD("vmm3",            "xc7s50csga324", "ft2232", 0, 0, CABLE_DEFAULT)
+	JTAG_BOARD("vmm3",            "xc7s50csga324", "ft2232", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("step-max10_v1",   "10m02scm153c8g", "usb-blaster",0, 0, CABLE_DEFAULT)
 };
 
 #endif


### PR DESCRIPTION
Description:
STEP-MAX10 V1 board has the chip of Altera 10M02SCM153C8G as the following images. This PR adds this board support. The official website is here: https://wiki.stepfpga.com/step-max10
![1](https://github.com/user-attachments/assets/11c12524-3194-4160-a300-33cbba8bd95c)
![2](https://github.com/user-attachments/assets/2eaa2d89-0ef2-41be-8613-148d29406acf)

Changes:
1. doc/FPGAs.yml:
      - added 10M02 in 'Max 10' section
3. doc/boards.yml:
      - added step-max10_v1 information
5. src/board.hpp:
      - added step-max10_v1 board support