### PR TITLE
Add STEP-MXO2 V2 Board Support.

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -1002,3 +1002,10 @@
   FPGA: Altera 10M02SCM153C8G
   Memory: OK
   Flash: NA
+
+- ID: step-mxo2_v2
+  Description: STEP MXO2 V2
+  URL: https://wiki.stepfpga.com/xo2-4000hc
+  FPGA: Lattice LCMXO2-4000HC-4MG132CC
+  Memory: OK
+  Flash: OK

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -254,7 +254,8 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("zybo_z7_20",      "xc7z020clg400",  "digilent", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("mini_itx",        "xc7z100ffg900", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("vmm3",            "xc7s50csga324", "ft2232", 0, 0, CABLE_DEFAULT),
-	JTAG_BOARD("step-max10_v1",   "10m02scm153c8g", "usb-blaster",0, 0, CABLE_DEFAULT)
+	JTAG_BOARD("step-max10_v1",   "10m02scm153c8g", "usb-blaster",0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("step-mxo2_v2",    "lcmxo2-4000hc-4mg132cc", "ft232",0, 0, CABLE_DEFAULT)
 };
 
 #endif


### PR DESCRIPTION
Description:
STEP-MXO2 V2 has the chip of Lattice LCMXO2-4000HC-4MG132CC and it also includes the FT232 chip for updating both RAM and FLASH. This PR adds this board support. The official website is at: https://wiki.stepfpga.com/xo2-4000hc

![1](https://github.com/user-attachments/assets/5c86bbd3-b253-4282-a2c5-94c96211b084)
![2](https://github.com/user-attachments/assets/a530c697-2508-49f4-8d42-5ec5e4988904)

Changes:
1. doc/boards.yml
    - added step-mxo2_v2 board information.
 2. src/board.hpp
    - added step-mxo2_v2 board support.