### PR TITLE
Fix snprintf usage

### DIFF
--- a/src/dfuFileParser.cpp
+++ b/src/dfuFileParser.cpp
@@ -119,13 +119,26 @@ int DFUFileParser::parseHeader()
 		{"idVendor", string(7, ' ')}, {"idProduct", string(7, ' ')},
 		{"bcdDevice", string(7, ' ')}};
 
-	snprintf(&_hdr["dwCRC"][0], 11, "0x%08x", _dwCRC);
+
+	char __buf[16];
+	int __buf_valid_bytes;
+	__buf_valid_bytes = snprintf(__buf, 11, "0x%08x", _dwCRC);
+	_hdr["dwCRC"] = string(__buf, __buf_valid_bytes);
+	_hdr["dwCRC"].resize(11, ' ');
 	_hdr["bLength"] = to_string(_bLength);
 	_hdr["ucDfuSignature"] = ucDfuSignature;
-	snprintf(&_hdr["bcdDFU"][0], 7, "0x%04x", _bcdDFU);
-	snprintf(&_hdr["idVendor"][0], 7, "0x%04x", _idVendor);
-	snprintf(&_hdr["idProduct"][0], 7, "0x%04x", _idProduct);
-	snprintf(&_hdr["bcdDevice"][0], 7, "0X%04x", _bcdDevice);
+	__buf_valid_bytes = snprintf(__buf, 7, "0x%04x", _bcdDFU);
+	_hdr["bcdDFU"] = string(__buf, __buf_valid_bytes);
+	_hdr["bcdDFU"].resize(7, ' ');
+	__buf_valid_bytes = snprintf(__buf, 7, "0x%04x", _idVendor);
+	_hdr["idVendor"] = string(__buf, __buf_valid_bytes);
+	_hdr["idVendor"].resize(7, ' ');
+	__buf_valid_bytes = snprintf(__buf, 7, "0x%04x", _idProduct);
+	_hdr["idProduct"] = string(__buf, __buf_valid_bytes);
+	_hdr["idProduct"].resize(7, ' ');
+	__buf_valid_bytes = snprintf(__buf, 7, "0x%04x", _bcdDevice);
+	_hdr["bcdDevice"] = string(__buf, __buf_valid_bytes);
+	_hdr["bcdDevice"].resize(7, ' ');
 
 	return 1;
 }

--- a/src/fsparser.cpp
+++ b/src/fsparser.cpp
@@ -63,15 +63,19 @@ int FsParser::parseHeader()
 		uint8_t key = c & 0x7F;
 		uint64_t val = bitToVal(buffer.c_str(), buffer.size());
 
+		char __buf[10];
+		int __buf_valid_bytes;
 		switch (key) {
 			case 0x06: /* idCode */
 				_idcode = (0xffffffff & val);
-				_hdr["idcode"] = string(8, ' ');
-				snprintf(&_hdr["idcode"][0], 9, "%08x", _idcode);
+				__buf_valid_bytes = snprintf(__buf, 9, "%08x", _idcode);
+				_hdr["idcode"] = string(__buf, __buf_valid_bytes);
+				_hdr["idcode"].resize(8, ' ');
 				break;
 			case 0x0A: /* user code or checksum ? */
-				_hdr["CheckSum"] = string(8, ' ');
-				snprintf(&_hdr["CheckSum"][0], 9, "%08x", (uint32_t)(0xffffffff & val));
+				__buf_valid_bytes = snprintf(__buf, 9, "%08x", (uint32_t)(0xffffffff & val));
+				_hdr["CheckSum"] = string(__buf, __buf_valid_bytes);
+				_hdr["CheckSum"].resize(8, ' ');
 				break;
 			case 0x0B: /* only present when bit_security is set */
 				_hdr["SecurityBit"] = "ON";
@@ -107,8 +111,9 @@ int FsParser::parseHeader()
 			case 0x52: /* documentation issue */
 				uint32_t flash_addr;
 				flash_addr = val & 0xffffffff;
-				_hdr["SPIAddr"] = string(8, ' ');
-				snprintf(&_hdr["SPIAddr"][0], 9, "%08x", flash_addr);
+				__buf_valid_bytes = snprintf(__buf, 9, "%08x", flash_addr);
+				_hdr["SPIAddr"] = string(__buf, __buf_valid_bytes);
+				_hdr["SPIAddr"].resize(8, ' ');
 
 				break;
 			case 0x3B: /* last header line with crc and cfg data length */

--- a/src/ftdipp_mpsse.cpp
+++ b/src/ftdipp_mpsse.cpp
@@ -402,20 +402,24 @@ int FTDIpp_MPSSE::setClkFreq(uint32_t clkHZ)
 	real_freq = base_freq / ((1+presc)*2);
 
 	/* just to have a better display */
-	string clkHZ_str(10, ' ');
-	string real_freq_str(10, ' ');
+	char __buf[16];
+	int __buf_valid_bytes;
 	if (clkHZ >= 1e6)
-		snprintf(&clkHZ_str[0], 9, "%2.2fMHz", clkHZ / 1e6);
+		__buf_valid_bytes = snprintf(__buf, 9, "%2.2fMHz", clkHZ / 1e6);
 	else if (clkHZ >= 1e3)
-		snprintf(&clkHZ_str[0], 10, "%3.2fKHz", clkHZ / 1e3);
+		__buf_valid_bytes = snprintf(__buf, 10, "%3.2fKHz", clkHZ / 1e3);
 	else
-		snprintf(&clkHZ_str[0], 10, "%3u.00Hz", clkHZ);
+		__buf_valid_bytes = snprintf(__buf, 10, "%3u.00Hz", clkHZ);
+	string clkHZ_str(__buf, __buf_valid_bytes);
+	clkHZ_str.resize(10, ' ');
 	if (real_freq >= 1e6)
-		snprintf(&real_freq_str[0], 9, "%2.2fMHz", real_freq / 1e6);
+		__buf_valid_bytes = snprintf(__buf, 9, "%2.2fMHz", real_freq / 1e6);
 	else if (real_freq >= 1e3)
-		snprintf(&real_freq_str[0], 10, "%3.2fKHz", real_freq / 1e3);
+		__buf_valid_bytes = snprintf(__buf, 10, "%3.2fKHz", real_freq / 1e3);
 	else
-		snprintf(&real_freq_str[0], 10, "%3.2fHz", real_freq);
+		__buf_valid_bytes = snprintf(__buf, 10, "%3.2fHz", real_freq);
+	string real_freq_str(__buf, __buf_valid_bytes);
+	real_freq_str.resize(10, ' ');
 
 
 	printInfo("Jtag frequency : requested " + clkHZ_str +

--- a/src/latticeBitParser.cpp
+++ b/src/latticeBitParser.cpp
@@ -124,8 +124,11 @@ int LatticeBitParser::parse()
 				continue;
 			string model = fpga.second.model;
 			if (subpart.compare(0, model.size(), model) == 0) {
-				_hdr["idcode"] = string(8, ' ');
-				snprintf(&_hdr["idcode"][0], 9, "%08x", fpga.first);
+				char __buf[10];
+				int __buf_valid_bytes;
+				__buf_valid_bytes = snprintf(__buf, 9, "%08x", fpga.first);
+				_hdr["idcode"] = string(__buf, __buf_valid_bytes);
+				_hdr["idcode"].resize(8, ' ');
 			}
 		}
 	}
@@ -172,6 +175,8 @@ bool LatticeBitParser::parseCfgData()
 	uint8_t *ptr;
 	size_t pos = _endHeader + 5;  // drop preamble
 	uint32_t idcode;
+	char __buf[10];
+	int __buf_valid_bytes;
 	while (pos < _raw_data.size()) {
 		uint8_t cmd = (uint8_t) _raw_data[pos++];
 		switch (cmd) {
@@ -186,8 +191,9 @@ bool LatticeBitParser::parseCfgData()
 					 (((uint32_t)reverseByte(ptr[5])) << 16) |
 					 (((uint32_t)reverseByte(ptr[4])) <<  8) |
 					 (((uint32_t)reverseByte(ptr[3])) <<  0);
-			_hdr["idcode"] = string(8, ' ');
-			snprintf(&_hdr["idcode"][0], 9, "%08x", idcode);
+			__buf_valid_bytes = snprintf(__buf, 9, "%08x", idcode);
+			_hdr["idcode"] = string(__buf, __buf_valid_bytes);
+			_hdr["idcode"].resize(8, ' ');
 			pos += 7;
 			if (!_is_machXO2)
 				return true;
@@ -198,8 +204,9 @@ bool LatticeBitParser::parseCfgData()
 					 (((uint32_t)ptr[4]) << 16) |
 					 (((uint32_t)ptr[5]) <<  8) |
 					 (((uint32_t)ptr[6]) <<  0);
-			_hdr["idcode"] = string(8, ' ');
-			snprintf(&_hdr["idcode"][0], 9, "%08x", idcode);
+			__buf_valid_bytes = snprintf(__buf, 9, "%08x", idcode);
+			_hdr["idcode"] = string(__buf, __buf_valid_bytes);
+			_hdr["idcode"].resize(8, ' ');
 			pos += 7;
 			if (!_is_machXO2)
 				return true;


### PR DESCRIPTION
Some code used snprintf on std::string objects.
This caused unexpected behaviour where '\0' was printed to the output file. 
This pull request adds intermediate char* buffer which is later used to initialize std::string.
This string is later resized to the correct expected length.