### PR TITLE
Added alinx_ax7203 and alinx_ax7201 boards

### DIFF
--- a/src/board.hpp
+++ b/src/board.hpp
@@ -111,6 +111,8 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("alinx_ax516",     "xc6slx16csg324", "",         0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("alinx_ax7101",    "xc7a100tfgg484", "",         0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("alinx_ax7102",    "xc7a100tfgg484", "",         0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("alinx_ax7203",    "xc7a200tfbg484", "",         0, 0, CABLE_DEFAULT),
+    JTAG_BOARD("alinx_ax7201",    "xc7a200tfbg484", "",         0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("antmicro_ddr4_tester", "xc7k160tffg676", "ft4232", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("antmicro_ddr5_tester", "xc7k160tffg676", "ft4232", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("antmicro_lpddr4_tester", "xc7k70tfbg484", "ft4232", 0, 0, CABLE_DEFAULT),


### PR DESCRIPTION
Added `alinx_ax7203` and `alinx_ax7201` boards to be able to be programmed with openFPGALoader. I had a problem with programming the board with [LiteX](https://github.com/enjoy-digital/litex) so I added the option to program the boards with `openFPGALoader` and tested it out with `./alinx_ax7203.py --load` and `./alinx_ax7201.py --load` commands.

The boards use an external JTAG programmer that has the FT232 chip.  Both the boards have the same FPGA chip which is 
`xc7a200tfbg484` with speed grade 2.

The pull request is being made because of the use of the aforementioned boards in the [wireguard-fpga](https://github.com/chili-chips-ba/wireguard-fpga) and [uberClock](https://github.com/chili-chips-ba/uberClock) project that use those boards.