### PR TITLE
xvc_server: Make thread exit cleanly

### DIFF
--- a/src/xvc_server.cpp
+++ b/src/xvc_server.cpp
@@ -148,6 +148,7 @@ void XVC_server::thread_listen()
 
 	maxfd = _sock;
 
+	try {
 	while (!_must_stop) {
 		fd_set read = conn, except = conn;
 		int fd;
@@ -203,6 +204,9 @@ void XVC_server::thread_listen()
 			}
 		}
 	}
+	} catch (const std::runtime_error& e) {
+		std::cerr << "thread exiting with error: " << e.what() << std::endl;
+	}
 	_is_stopped = true;
 }
 
@@ -216,6 +220,7 @@ bool XVC_server::listen_loop()
 	_must_stop = true;
 	close_connection();
 	while (!_is_stopped){}
+	_thread->join();
 	delete _thread;
 
 	return true;


### PR DESCRIPTION
If a thread throws an exception, the application will `abort()` through the `terminate()` function, preventing cleanup code from being run.

Without this fix, "pressing" to quit XVC server mode looks like this:

```
Press to quit

Read error (-1) 9 Bad file descriptor

connection closed - fd 8
terminate called after throwing an instance of 'std::runtime_error'
  what():  communication failure
zsh: IOT instruction  ./openFPGALoader --xvc
```

The application exits on a signal, and no cleanup is done.  With the fix, we get this instead:

```
Press to quit

Read error (-1) 9 Bad file descriptor

connection closed - fd 8
thread exiting with error: communication failure
Xilinx Virtual Cable Stopped! 
```

I also added the missing call to `join()`, which should make the `_is_stopped` spin redundant, but I left it there for now...

Also, I know the indentation is not optimal, but I wanted the diff to reflect the actual changes and not a lot of reindentation.  :smile_cat: 