### PR TITLE
gowin: Fix compilation on musl

### DIFF
--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -252,6 +252,8 @@ bool Gowin::send_command(uint8_t cmd)
 			#define le32toh(x) (x)
 		#endif
 	#endif
+#else
+#include <endian.h>
 #endif
 
 uint32_t Gowin::readReg32(uint8_t cmd)


### PR DESCRIPTION
`gowin.cpp` uses the functions `htole32()` and `le32toh()` without including the prerequisite header `<endian.h>`.  This breaks the build when using the musl libc.