### PR TITLE
libgpiodJtagBitbang: add support for XVC server

### DIFF
--- a/src/libgpiodJtagBitbang.hpp
+++ b/src/libgpiodJtagBitbang.hpp
@@ -36,6 +36,8 @@ class LibgpiodJtagBitbang : public JtagInterface {
 	int writeTMS(const uint8_t *tms_buf, uint32_t len, bool flush_buffer, const uint8_t tdi = 1) override;
 	int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
 	int toggleClk(uint8_t tms, uint8_t tdo, uint32_t clk_len) override;
+	bool writeTMSTDI(const uint8_t *tms, const uint8_t *tdi, uint8_t *tdo,
+			 uint32_t len) override;
 
 	int get_buffer_size() override { return 0; }
 	bool isFull() override { return false; }

--- a/src/xvc_server.cpp
+++ b/src/xvc_server.cpp
@@ -14,6 +14,9 @@
 #include <stdexcept>
 
 #include "ftdiJtagMPSSE.hpp"
+#ifdef ENABLE_LIBGPIOD
+#include "libgpiodJtagBitbang.hpp"
+#endif
 #include "cable.hpp"
 #include "display.hpp"
 
@@ -36,6 +39,11 @@ XVC_server::XVC_server(int port, const cable_t & cable,
 		_jtag = new FtdiJtagMPSSE(cable, dev, serial, clkHZ,
 					  invert_read_edge, _verbose);
 		break;
+#ifdef ENABLE_LIBGPIOD
+	case MODE_LIBGPIOD_BITBANG:
+		_jtag = new LibgpiodJtagBitbang(pin_conf, dev, clkHZ, verbose);
+		break;
+#endif
 #if 0
 	case MODE_ANLOGICCABLE:
 		_jtag = new AnlogicCable(clkHZ);


### PR DESCRIPTION
Adds the method `writeTMSTDI()` to the libgpiod bitbang driver, making it usable for the XVC server mode.

I have only tested the APIV2 code, but the other one should work for symmetry reasons.  :smile_cat: 