### PR TITLE
kcu105: add support for secondary QSPI

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -494,7 +494,7 @@
   URL: https://www.xilinx.com/products/boards-and-kits/kcu105.html
   FPGA: Kintex UltraScale xcku040-ffva1156
   Memory: OK
-  Flash: OK
+  Flash: OK (primary and secondary)
 
 - ID: kcu116
   Description: Xilinx KCU116

--- a/doc/guide/advanced.rst
+++ b/doc/guide/advanced.rst
@@ -34,7 +34,7 @@ Reading the bitstream from STDIN
   .. code-block:: bash
 
     # FPGA side
-    nc -lp port | openFPGALoader --file-type xxx [option
+    nc -lp port | openFPGALoader --file-type xxx [option]
 
     # Bitstream side
     nc -q 0 host port < /path/to/bitstream.ext
@@ -82,6 +82,35 @@ Writing to an arbitrary address in flash memory
 
 With FPGA using an external SPI flash (*xilinx*, *lattice ECP5/nexus/ice40*, *anlogic*, *efinix*) option ``-o`` allows
 one to write raw binary file to an arbitrary adress in FLASH.
+
+Detect/read/write on primary/secondary flash memories
+=====================================================
+
+With FPGA using two external SPI flash (some *xilinx* boards) option ``--target-flash`` allows to select the QSPI chip.
+
+To detect:
+
+.. code-block:: bash
+
+    openFPGALoader -b kcu105 -f --target-flash {primary,secondary} --detect
+
+To read the primary flash memory:
+
+.. code-block:: bash
+
+    openFPGALoader -b kcu105 -f --target-flash primary --dump-flash --file-size N_BYTES mydump.bin
+
+and the second flash memory:
+
+.. code-block:: bash
+
+    openFPGALoader -b kcu105 -f --target-flash secondary --dump-flash --file-size N_BYTES --secondary-bitstream mydump.bin
+
+To write on secondary flash memory:
+
+.. code-block:: bash
+
+    openFPGALoader -b kcu105 -f --target-flash secondary --secondary-bitstream mySecondaryBitstream.bin
 
 Using an alternative directory for *spiOverJtag*
 ================================================

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -174,7 +174,7 @@ static std::map <std::string, target_board_t> board_list = {
 			0, 0, CABLE_DEFAULT),
 	DFU_BOARD("icebreaker-bitsy", "", "dfu", 0x1d50, 0x6146, 0),
 	JTAG_BOARD("kc705",           "", "digilent", 0, 0, CABLE_DEFAULT),
-	JTAG_BOARD("kcu105",          "", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("kcu105",          "xcku040-ffva1156", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("kcu116",          "xcku5p-ffvb676", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("LD-SCHOKO",       "LFE5U-45F-6CABGA256", "", 0, 0, CABLE_MHZ(6)),
 	DFU_BOARD("LD-SCHOKO-DFU",        "", "dfu", 0x16d0, 0x116d, 0),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1044,7 +1044,8 @@ int parse_opt(int argc, char **argv, struct arguments *args,
 				 args->secondary_bit_file.empty() &&
 				 !args->protect_flash &&
 				 !args->unprotect_flash &&
-				 !args->bulk_erase_flash
+				 !args->bulk_erase_flash &&
+				 !args->detect
 				) {
 				printError("Error: secondary bitfile not specified");
 				cout << options.help() << endl;

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -313,7 +313,7 @@ Xilinx::Xilinx(Jtag *jtag, const std::string &filename,
 		_secondary_file_extension = secondary_filename.substr(
 			secondary_filename.find_last_of(".") + 1);
 		_mode = Device::SPI_MODE;
-		if (!(_device_package == "xcvu9p-flga2104" || _device_package == "xcku5p-ffvb676")) {
+		if (!(_device_package == "xcvu9p-flga2104" || _device_package == "xcku5p-ffvb676" || _device_package == "xcku040-ffva1156")) {
 			throw std::runtime_error("Error: secondary flash unavailable");
 		}
 	}


### PR DESCRIPTION
Hi Trabucayre,

This PR enable the detection and the dump of the secondary QSPI.

Tested on KCU105:

- [x]  `--detect`  on primary and secondary QSPI
- [x]  `--dump-flash`  on primary and secondary QSPI
- [x]  `-f`  on secondary QSPI