### PR TITLE
Fix incompatibility with Lattice FPGA

### DIFF
--- a/src/svf_jtag.cpp
+++ b/src/svf_jtag.cpp
@@ -230,7 +230,9 @@ void SVF_jtag::parse_runtest(vector<string> const &vstr)
 	}
 	_jtag->set_state(_run_state);
 	_jtag->toggleClk(nb_iter);
-	if (min_duration > 0) {
+	_jtag->flush();
+	if (min_duration > 0)
+	{
 		usleep((useconds_t)(min_duration * 1.0E6));
 	}
 	_jtag->set_state(_end_state);


### PR DESCRIPTION
It looks like the LFE5U-85F fails to execute this SVF fragment:
! Shift in ISC ERASE(0x0E) instruction
SIR	8	TDI  (0E);
SDR	8	TDI  (01);
RUNTEST	IDLE	2 TCK	20.00E-03 SEC;


! Program Fuse Map

! Shift in LSC_READ_STATUS(0x3C) instruction
SIR	8	TDI  (3C);
SDR	32	TDI  (00000000)
		TDO  (00000000)
		MASK (0000B000);

The problem is with this:
RUNTEST	IDLE	2 TCK	20.00E-03 SEC;
If the jtag device isn't flushed before the host sleeps, the 2 clocks arrive just before the SIR and the FPGA sets a busy bit that fails the TDO check. In a way the sleep gets ahead of the 2 TCK. 
One can argue that the flush is really necessary only when min_duration is greater than 0  but it is hard to test so I prefer being conservative. 