### PR TITLE
Add support for Numatolab Neso board.

### DIFF
--- a/src/board.hpp
+++ b/src/board.hpp
@@ -188,6 +188,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("machXO3SK",       "", "ft2232",     0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("machXO3EVN",      "", "ft2232",     0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("mimas_a7",		  "xc7a50tfgg484",	"numato", 0, 0, CABLE_MHZ(30)),
+	JTAG_BOARD("neso_a7",         "xc7a100tcsg324",	"numato-neso", 0, 0, CABLE_MHZ(30)),
 	JTAG_BOARD("minispartan6",    "", "ft2232",    0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("nexys_a7_50",     "xc7a50tcsg324",  "digilent", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("nexys_a7_100",    "xc7a100tcsg324", "digilent", 0, 0, CABLE_DEFAULT),

--- a/src/cable.hpp
+++ b/src/cable.hpp
@@ -123,6 +123,7 @@ static std::map <std::string, cable_t> cable_list = {
 	{"jtag-smt2-nc",       FTDI_SER(0x0403, 0x6014, FTDI_INTF_A, 0xe8, 0xeb, 0x00, 0x60)},
 	{"lpc-link2",          CMSIS_CL(0x1fc9, 0x0090                                     )},
 	{"numato",			   FTDI_SER(0x2a19, 0x1009, FTDI_INTF_B, 0x08, 0x4b, 0x00, 0x00)},
+	{"numato-neso",	       FTDI_SER(0x2a19, 0x1005, FTDI_INTF_B, 0x08, 0x4b, 0x00, 0x00)},
 	{"orbtrace",           CMSIS_CL(0x1209, 0x3443                                     )},
 	{"papilio",            FTDI_SER(0x0403, 0x6010, FTDI_INTF_A, 0x08, 0x0B, 0x09, 0x0B)},
 	{"steppenprobe",       FTDI_SER(0x0403, 0x6010, FTDI_INTF_A, 0x58, 0xFB, 0x00, 0x99)},


### PR DESCRIPTION
Programming SRAM over USB works, when board jumpers are set for JTAG programming mode.

SPI flashing does not work properly (does not boot).
Readback of SPI data yields identical bitstream.

These changes are only tested with hardware revision 2 of the board.

This commit adds:
* a new cable `numato-neso`.
* a new board `neso_a7`.

Usage (programming):
`openFPGALoader -b neso_a7 top.bit`

Usage (flashing):
`openFPGALoader -b neso_a7 -f top.bit`

Detecting flash works:
```
openFPGALoader -b neso_a7 -f --detect
empty
write to flash
Jtag frequency : requested 30.00MHz   -> real 30.00MHz  
protect_flash: use: openFPGALoader/spiOverJtag//spiOverJtag_xc7a100tcsg324.bit.gz
load program
Load SRAM: [==================================================] 100.00%
Done
Shift IR 35
ir: 1 isc_done 1 isc_ena 0 init 1 done 1
JEDEC ID: 0x9d6018
Detected: ISSI IS25LP128 256 sectors size: 128Mb
RDSR : 0x00
WIP  : 0
WEL  : 0
BP   : 0
QE   : 0
SRWD : 0

Function Register
RDFR : 01
RES  : 1
TBS  : 0
PSUS : 0
ESUS : 0
IRL  : 0
Done
```