### PR TITLE
Add support for Digilent Anvyl, the Big Red Board.

### DIFF
--- a/src/board.hpp
+++ b/src/board.hpp
@@ -116,6 +116,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("antmicro_ddr4_tester", "xc7k160tffg676", "ft4232", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("antmicro_ddr5_tester", "xc7k160tffg676", "ft4232", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("antmicro_lpddr4_tester", "xc7k70tfbg484", "ft4232", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("anvyl",           "xc6slx45csg484", "digilent", 0, 0, CABLE_DEFAULT),
 	/* left for backward compatibility, use right name instead */
 	JTAG_BOARD("arty",            "xc7a35tcsg324",  "digilent", 0, 0, CABLE_MHZ(10)),
 	JTAG_BOARD("arty_a7_35t",     "xc7a35tcsg324",  "digilent", 0, 0, CABLE_MHZ(10)),


### PR DESCRIPTION
Programming to SRAM works. Programming flash works with a renamed spiOverJtag bitfile - cs(g)484 is different from fg(g)484, but the configuration flash IOs all end up on the same pads in the end.

(As an aside: I suspect that more Xilinx bitstreams are being generated than are actually needed. There's no physical difference between the silicon for e.g. xc6slx45csg324, xc6slx45fgg484, and xc6slx45csg484 - the configuration flash is connected to the same pads on each part, the pins are just named differently. As such, the same bitstream can be used for any package containing that part.)