### PR TITLE
Adding support for Open Source SDR Lab Kintex-7 325t FPGA Board

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -603,6 +603,13 @@
   Memory: OK
   Flash: NT
 
+- ID: opensourceSDRLabKintex7
+  Description: Open Source SDR Lab Kintex-7 325t FPGA PCIE Development Board
+  URL: https://opensourcesdrlab.com/products/fpga-xilinx-kintex-7-xc7k325t-pcie-development-board-with-dual-gigabit-ethernet-ports-dual-10-gigabit-sfp-optical-communication
+  FPGA: Kintex7 xc7k325tffg676
+  Memory: OK
+  Flash: OK
+
 - ID: orbtrace_dfu
   Description: ORBTrace mini (dfu mode)
   URL: https://store.zyp.no/product/orbtrace-mini

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -200,6 +200,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("nexys_a7_100",    "xc7a100tcsg324", "digilent", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("nexysVideo",      "xc7a200tsbg484", "digilent_b", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("olimex_gatemateevb", "GM1A1", "dirtyJtag", 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("opensourceSDRLabKintex7", "xc7k325tffg676", "ft232", 0, 0, CABLE_DEFAULT),
 	DFU_BOARD("orangeCrab",       "", "dfu", 0x1209, 0x5af0, 0),
 	DFU_BOARD("orbtrace_dfu",     "", "dfu", 0x1209, 0x3442, 1),
 	JTAG_BOARD("papilio_one",     "xc3s500evq100", "papilio", 0, 0, CABLE_DEFAULT),


### PR DESCRIPTION
This Pull request adds support for Open Source SDR Lab Kintex-7 325t FPGA PCIE Development Board

![image](https://github.com/user-attachments/assets/0be1f5d5-89d9-4d31-bee8-d34b3aef81ee)
![image](https://github.com/user-attachments/assets/afece8de-24a9-4abc-b078-cdd55861ed67)
![image](https://github.com/user-attachments/assets/e4bbe2a8-99b5-4601-bd3b-b7fbd99d594d)
