### PR TITLE
Fix the failure of old Anlogic Cable and add support for Anlogic EG4D20EG176

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -1,14 +1,16 @@
 Anlogic:
 
   - Description: EG4
-    Model: S20
-    URL: http://www.anlogic.com/prod_view.aspx?TypeId=10&Id=168&FId=t3:10:3
+    Model:
+      - EG4D20
+      - EG4S20
+    URL: https://www.anlogic.com/en/product/fpga/saleagle/eg4
     Memory: OK
     Flash: AS
 
   - Description: SALELF 2
     Model: EF2M45
-    URL: http://www.anlogic.com/prod_view.aspx?TypeId=12&Id=170&FId=t3:12:3
+    URL: https://www.anlogic.com/en/product/fpga/salelf/salelf2
     Memory: OK
     Flash: OK
 

--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -552,6 +552,13 @@
   Memory: OK
   Flash: OK
 
+- ID: mlk-s200-eg4d20
+  Description: MILIANKE S200 EG4D20 Development Board
+  URL: https://www.milianke.com/product-item-108.html
+  FPGA: eagle s20 EG4D20EG176
+  Memory: OK
+  Flash: OK
+
 - ID: mini_itx
   Description: Avnet Mini-ITX Base Kit
   URL: https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/mini-itx/

--- a/src/anlogicCable.cpp
+++ b/src/anlogicCable.cpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-#define ANLOGICCABLE_VIDv1 0x336C
+#define ANLOGICCABLE_VIDv1 0x0547
 #define ANLOGICCABLE_VIDv2 0x336C
 #define ANLOGICCABLE_PID   0x1002
 

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -193,6 +193,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("machXO2EVN",      "", "ft2232",     0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("machXO3SK",       "", "ft2232",     0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("machXO3EVN",      "", "ft2232",     0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("mlk-s200-eg4d20", "", "anlogicCable", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("mimas_a7",		  "xc7a50tfgg484",	"numato", 0, 0, CABLE_MHZ(30)),
 	JTAG_BOARD("neso_a7",         "xc7a100tcsg324",	"numato-neso", 0, 0, CABLE_MHZ(30)),
 	JTAG_BOARD("minispartan6",    "", "ft2232",    0, 0, CABLE_DEFAULT),

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -24,6 +24,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	/**************************************************************************/
 
 	/* Anlogic Eagle */
+	{0x04014c35, {"anlogic", "eagle d20", "EG4D20EG176", 8}},
 	{0x0a014c35, {"anlogic", "eagle s20", "EG4S20BG256", 8}},
 
 	/* Anlogic Elf2 */


### PR DESCRIPTION
1. Fix ANLOGICCABLE_VIDv1 to correct old value.
2. Add support for Anlogic EG4D20EG176 FPGA.
3. Add support for MLK-S200-EG4D20 board.
4. Update related document and outdated URL.

```
-> % ./openFPGALoader -b mlk-s200-eg4d20 --detect
empty
Jtag frequency : requested 6000000Hz -> real 6000000Hz
index 0:
        idcode 0x4014c35
        manufacturer anlogic
        family eagle d20
        model  EG4D20EG176
        irlength 8

-> % ./openFPGALoader -b mlk-s200-eg4d20 mlk_s200_eg4d20.bit
empty
Jtag frequency : requested 6000000Hz -> real 6000000Hz
Parse file header end
DONE
Loading: [===================================================] 100.00%
Done

-> % ./openFPGALoader -b mlk-s200-eg4d20 -f mlk_s200_eg4d20.bit
empty
write to flash
Jtag frequency : requested 6000000Hz -> real 6000000Hz
Parse file header end
DONE
JEDEC ID: 0xef4015
Detected: Winbond W25Q16 32 sectors size: 16Mb
00000000 00000000 00000000 00
start addr: 00000000, end_addr: 000b0000
Erasing: [==================================================] 100.00%
Done
Writing: [===================================================] 100.00%
Done
```