### PR TITLE
Add support for icepi zero

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -481,6 +481,13 @@
   Flash: AS
   Constraints: IceZumAlhambraII
 
+- ID: icepi-zero
+  Description: Icepi Zero
+  URL: https://github.com/cheyao/icepi-zero
+  FPGA: ECP5 LFE5U
+  Memory: OK
+  Flash: OK
+
 - ID: kc705
   Description: Xilinx KC705
   URL: https://www.xilinx.com/products/boards-and-kits/ek-k7-kc705-g.html

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -179,6 +179,8 @@ static std::map <std::string, target_board_t> board_list = {
 			DBUS4, DBUS0, DBUS1, DBUS2,
 			0, 0, CABLE_DEFAULT),
 	DFU_BOARD("icebreaker-bitsy", "", "dfu", 0x1d50, 0x6146, 0),
+	JTAG_BITBANG_BOARD("icepi-zero",   "", "ft231X",  0, 0,
+			FT232RL_DCD, FT232RL_DSR, FT232RL_RI, FT232RL_CTS, CABLE_DEFAULT),
 	JTAG_BOARD("kc705",           "", "digilent", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("kcu105",          "xcku040-ffva1156", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("kcu116",          "xcku5p-ffvb676", "jtag-smt2-nc", 0, 0, CABLE_DEFAULT),


### PR DESCRIPTION
Hello!

I've made my own fpga board called [icepi zero](https://github.com/cheyao/icepi-zero). This might be offered as a prize in a hackathon @ Github hq (Check out [undercity](https://highway.hackclub.com/getting-started/undercity)!! I'm part of the organizing team), so I would like to add it to the supported boards list beforehand :D

Thanks.