### PR TITLE
Add cable support for ARM-USB-TINY-H based off ARM-USB-OCD-H

### DIFF
--- a/src/cable.hpp
+++ b/src/cable.hpp
@@ -87,6 +87,7 @@ static std::map <std::string, cable_t> cable_list = {
 	// some cables requires explicit values on some of the I/Os
 	{"anlogicCable",       CABLE_DEF(MODE_ANLOGICCABLE, 0x0547, 0x1002)},
 	{"arm-usb-ocd-h",      FTDI_SER(0x15ba, 0x002b, FTDI_INTF_A, 0x08, 0x1B, 0x09, 0x0B)},
+	{"arm-usb-tiny-h",     FTDI_SER(0x15ba, 0x002a, FTDI_INTF_A, 0x08, 0x1B, 0x09, 0x0B)},
 	{"bus_blaster",        FTDI_SER(0x0403, 0x6010, FTDI_INTF_A, 0x08, 0x1B, 0x08, 0x0B)},
 	{"bus_blaster_b",      FTDI_SER(0x0403, 0x6010, FTDI_INTF_B, 0x08, 0x0B, 0x08, 0x0B)},
 	{"ch552_jtag",         FTDI_SER(0x0403, 0x6010, FTDI_INTF_A, 0x08, 0x0B, 0x08, 0x0B)},


### PR DESCRIPTION
Fixes #562. The existing code suffices to use the new device as a JTAG programmer.

This assumption has been tested by forcing the VID:PID pair using `--vid 0x15ba --pid 0x002a`, but the PR itself remains untested until I have access to the device (this Thursday).