### PR TITLE
cmsisDAP: Avoid memcpy() on possibly overlapping buffer

### DIFF
--- a/src/cmsisDAP.cpp
+++ b/src/cmsisDAP.cpp
@@ -561,7 +561,7 @@ int CmsisDAP::xfer(int tx_len, uint8_t *rx_buff, int rx_len)
 		return ret;
 	}
 	if (rx_len)
-		memcpy(rx_buff, _ll_buffer, rx_len);
+		memmove(rx_buff, _ll_buffer, rx_len);
 
 
 	return ret;


### PR DESCRIPTION
I observed strange cmsisDAP behavior when building openFPGALoader with Clang/musl in release mode: CmsisDAP:display_info() shows the correct hardware capability that supports JTAG,

	...
	firmware version : 0254
	hardware capabilities : 13
	SWO trace buffer size : NA
	...

but the detection of JTAG fails in the constructor with a strange response sequence,

	Hardware cap 00 01 00
	JTAG init failed with: JTAG is not supported by the probe

With some digging, it's found that the CmsisDAP::xfer() method without an instruction parameter may be called by the constructor with a rx_buff pointer overlapping with _ll_buffer, for which memmove() instead of memcpy() should be used. The behavior of memcpy() is undefined when dst and src overlap.

Fixes: 53c5d35da6ca ("add cmsis dap (hid) support")