### PR TITLE
Add Altera Cyclone 10 LP 10CL080 support

### DIFF
--- a/src/part.hpp
+++ b/src/part.hpp
@@ -220,6 +220,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	/* Altera Cyclone 10 */
 	{0x020f30dd, {"altera", "cyclone 10 LP", "10CL025", 10}},
 	{0x020f50dd, {"altera", "cyclone 10 LP", "10CL055", 10}},
+	{0x020f60dd, {"altera", "cyclone 10 LP", "10CL080", 10}},
 
 	/* Altera Stratix V */
 	{0x029070dd, {"altera", "stratix V GS", "5SGSD5", 10}},


### PR DESCRIPTION
Very few changes here, but good results :)

```
$ openFPGALoader -c usb-blaster --detect
empty
index 0:
        idcode 0x20f60dd
        manufacturer altera
        family cyclone 10 LP
        model  10CL080
        irlength 10

$ openFPGALoader -v -c usb-blaster --fpga-part 10CL080 \
  build/qmtech_cyclone10_starterkit/gateware/qmtech_cyclone10_starterkit.rbf 
empty
found 1 devices
index 0:
        idcode 0x20f60dd
        manufacturer altera
        family cyclone 10 LP
        model  10CL080
        irlength 10
File type : rbf
Load SRAM: [==================================================] 100.00%
```