### PR TITLE
spiFlash: mask RDSR_WIP instead of RDSR_WEL while waiting for completion

### DIFF
--- a/src/spiFlash.cpp
+++ b/src/spiFlash.cpp
@@ -970,7 +970,7 @@ bool SPIFlash::set_quad_bit(bool set_quad)
 	_spi->spi_put(reg_wr, (uint8_t *)&reg_val, NULL, nb_wr_byte);
 
 	/* Wait for completion */
-	if (_spi->spi_wait(FLASH_RDSR, FLASH_RDSR_WEL, 0x00, 10000) != 0) {
+	if (_spi->spi_wait(FLASH_RDSR, FLASH_RDSR_WIP, 0x00, 10000) != 0) {
 		printError("SPIFlash Error: failed to disable write");
 		return false;
 	}


### PR DESCRIPTION
Just a very minor fix:

During testing with [AT25QL321](https://www.mouser.at/datasheet/3/1166/1/REN_DS-AT25QL321-131E-022023_DST_20230327_2.pdf) for ULX5M, I noticed that when changing the quad enable bit, we wait for the write enable latch (WEL) instead of the busy flag (WIP).

This resulted in the loop already being interrupted, even though the busy flag was still active.