### PR TITLE
Update part.hpp to support Lattice LFE3-150EA device

### DIFF
--- a/src/part.hpp
+++ b/src/part.hpp
@@ -301,6 +301,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 
 	/* Lattice ECP3 */
 	{0x01014043, {"lattice", "ECP3", "LFE3-70E",    8}},
+	{0x01015043, {"lattice", "ECP3", "LFE3-150EA",  8}},
 
 	/* Lattice ECP5 */
 	{0x21111043, {"lattice", "ECP5", "LFE5U-12",    8}},


### PR DESCRIPTION
This PR adds device ID support for the Lattice ECP3 LFE3-150EA. Previously, only the LFE3-70E was supported.

We've tested the implementation and confirmed it works as expected. We're happy to contribute to expanding ECP3 device support!