### PR TITLE
Correct .mcs file parser length calculation

### DIFF
--- a/src/mcsParser.cpp
+++ b/src/mcsParser.cpp
@@ -85,8 +85,6 @@ int McsParser::parse()
 			_bit_length += (byteLen * 8);
 			break;
 		case 1:
-			if (_bit_data.size() * 8 != (size_t)_bit_length)
-				_bit_length = _bit_data.size() * 8;
 			return EXIT_SUCCESS;
 			break;
 		case 4:


### PR DESCRIPTION
Commit 2ee72c055 introduced some sanity checks for address and buffer length. One of the checks added was to check that the size of the buffer and the size of the calculated bitlength is the same. However, since the buffer length starts off as the size of the .mcs file, the bit length you end up with is too long

The result of this is that the tool will erase/write more blocks than it should and take much longer to program the flash.

Deleting the added check results in the correct length. The other checks introduced in the patch are probably reasonable, essentially it is assuming that the start address is always zero. Since the offset to start programming the SPI flash comes from the command line, not the .mcs file start address, this seems OK.

An alternative fix is to set the initial buffer size to zero, but this means it will be reallocating all the time.