### PR TITLE
src/gowin: Add support for GW5AT-15 (used on Sipeed Slogic16U3).

### DIFF
--- a/src/fsparser.cpp
+++ b/src/fsparser.cpp
@@ -195,6 +195,7 @@ int FsParser::parse()
 			nb_line = 2038;
 			break;
 		case 0x0001281b: /* GW5A-25 */
+		case 0x0001681b: /* GW5AT-15 */
 		case 0x0001481b: /* GW5AT-60 */
 		case 0x0001081b: /* GW5AST-138 */
 			/*

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -217,6 +217,7 @@ bool Gowin::detectFamily()
 			is_gw2a = true;
 			break;
 		case 0x0001081b: /* GW5AST-138 */
+		case 0x0001681b: /* GW5AT-15 */
 		case 0x0001481b: /* GW5AT-60 */
 		case 0x0001181b: /* GW5AT-138 */
 		case 0x0001281b: /* GW5A-25 */

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -349,6 +349,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 
 	/* Gowin GW5 */
 	{0x0001081b, {"Gowin", "GW5AST", "GW5AST-138", 8}},
+	{0x0001681b, {"Gowin", "GW5AT",  "GW5AT-15",   8}},
 	{0x0001481b, {"Gowin", "GW5AT",  "GW5AT-60",   8}},
 	{0x0001181b, {"Gowin", "GW5AT",  "GW5AT-138",  8}},
 	{0x0001281b, {"Gowin", "GW5A",   "GW5A-25",    8}},


### PR DESCRIPTION
JTAG pinout on Sipeed Slogic16U3 is similar to Sipeed Tang Primier 20K JTAG pinout and extension cable from Tang Primer 20K can be used.

./openFPGALoader -c digilent_hs2 --detect
empty
Jtag frequency : requested 6.00MHz    -> real 6.00MHz
index 0:
	idcode 0x1681b
	manufacturer Gowin
	family GW5AT
	model  GW5AT-15
	irlength 8