### PR TITLE
efinix: Add header parsing and flash programming validation

### DIFF
--- a/src/efinix.cpp
+++ b/src/efinix.cpp
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -204,6 +205,29 @@ void Efinix::program(unsigned int offset, bool unprotect_flash)
 
 	if (_verbose)
 		bit->displayHeader();
+
+	if (_mode == FLASH_MODE) {
+		try {
+			if (!_device_package.empty()) {
+				std::string device = bit->getHeaderVal("device");
+				std::transform(device.begin(), device.end(), device.begin(), ::tolower);
+				std::string target = _device_package;
+				std::transform(target.begin(), target.end(), target.begin(), ::tolower);
+				if (!device.empty() && device != target) {
+					delete bit;
+					throw std::runtime_error("device mismatch: " + device + " != " + target);
+				}
+			}
+			std::string mode = bit->getHeaderVal("mode");
+			if (mode.find("passive") != std::string::npos) {
+				delete bit;
+				throw std::runtime_error("passive mode not supported for flash");
+			}
+		} catch (std::runtime_error& e) {
+			throw;
+		} catch (...) {
+		}
+	}
 
 	switch (_mode) {
 		case MEM_MODE:

--- a/src/efinixHexParser.cpp
+++ b/src/efinixHexParser.cpp
@@ -17,9 +17,55 @@ EfinixHexParser::EfinixHexParser(const string &filename):
 		false)
 {}
 
+int EfinixHexParser::parseHeader()
+{
+	string buffer;
+	istringstream lineStream(_raw_data);
+	int bytesRead = 0;
+	string headerText;
+	bool foundPaddedBits = false;
+	
+	while (std::getline(lineStream, buffer, '\n')) {
+		bytesRead += buffer.size() + 1;
+		
+		if (buffer != "0A") {
+			try {
+				uint8_t byte = std::stol(buffer, nullptr, 16);
+				headerText += (char)byte;
+			} catch (...) {
+			}
+		} else {
+			headerText += '\n';
+			if (foundPaddedBits)
+				break;
+		}
+		
+		if (headerText.find("PADDED_BITS") != string::npos)
+			foundPaddedBits = true;
+	}
+	
+	size_t pos;
+	if ((pos = headerText.find("Mode: ")) != string::npos) {
+		size_t end = headerText.find('\n', pos);
+		_hdr["mode"] = headerText.substr(pos + 6, end - pos - 6);
+	}
+	if ((pos = headerText.find("Width: ")) != string::npos) {
+		size_t end = headerText.find('\n', pos);
+		_hdr["width"] = headerText.substr(pos + 7, end - pos - 7);
+	}
+	if ((pos = headerText.find("Device: ")) != string::npos) {
+		size_t end = headerText.find('\n', pos);
+		_hdr["device"] = headerText.substr(pos + 8, end - pos - 8);
+	}
+	
+	return bytesRead;
+}
+
 int EfinixHexParser::parse()
 {
 	string buffer;
+	parseHeader();
+	
 	istringstream lineStream(_raw_data);
 
 	while (std::getline(lineStream, buffer, '\n')) {

--- a/src/efinixHexParser.hpp
+++ b/src/efinixHexParser.hpp
@@ -28,6 +28,9 @@ class EfinixHexParser: public ConfigBitstreamParser {
 		 * \return EXIT_SUCCESS is file is fully read, EXIT_FAILURE otherwise
 		 */
 		int parse() override;
+	
+	private:
+		int parseHeader();
 };
 
 #endif  // SRC_EFINIXHEXPARSER_HPP_


### PR DESCRIPTION
Parse bitstream header to extract Mode, Width and Device fields. Add validation for flash programming:
- Check device matches --fpga-part parameter
- Reject passive mode (only active mode supported for flash)

This prevents flashing incorrect bitstreams that would fail to boot.

I tested with the T120F324 and also extracted SPI-over-JTAG bit files for T8F81, T13F256, TI60F255, and TI180J484 for verification.