### PR TITLE
anlogic: fix high frequency flash programming issue

### DIFF
--- a/src/anlogic.hpp
+++ b/src/anlogic.hpp
@@ -69,9 +69,16 @@ class Anlogic: public Device, SPIInterface {
 		 */
 		virtual bool prepare_flash_access() override;
 		/*!
+		 * \brief restore frequency after flash ID read
+		 */
+		virtual void restore_flash_access_frequency() override;
+		/*!
 		 * \brief end of device to SPI access
 		 */
 		virtual bool post_flash_access() override {reset(); return true;}
+
+private:
+		uint32_t _target_freq; /*< target JTAG frequency */
 
 };
 

--- a/src/spiInterface.cpp
+++ b/src/spiInterface.cpp
@@ -187,6 +187,7 @@ bool SPIInterface::write(uint32_t offset, const uint8_t *data, uint32_t len,
 	/* test SPI */
 	try {
 		SPIFlash flash(this, unprotect_flash, _spif_verbose);
+		restore_flash_access_frequency();
 		flash.read_status_reg();
 		if (flash.erase_and_prog(offset, data, len) == -1)
 			ret = false;

--- a/src/spiInterface.hpp
+++ b/src/spiInterface.hpp
@@ -109,6 +109,10 @@ class SPIInterface {
 	 */
 	virtual bool prepare_flash_access() {return false;}
 	/*!
+	 * \brief restore frequency after flash ID read
+	 */
+	virtual void restore_flash_access_frequency() {}
+	/*!
 	 * \brief end of SPI flash access
 	 */
 	virtual bool post_flash_access() {return false;}


### PR DESCRIPTION
When programming the flash on my `EG4S20BG256` at `15 MHz`, an error occurs. Details:  
```
Jedec ID: ff  
Memory type: ff  
Memory capacity: ff  
Flash chip unknown: use basic protection detection  
Unlock blocks  
Error: block protection is set.  
Cannot unlock without --unprotect-flash  
```
This issue arises because reading the ID cannot be performed at too high a clock frequency. I resolved this by limiting the clock frequency for reading the ID. The official programming tool also adjusts the frequency dynamically, though it is more conservative than my code—I recall it drops to 3 MHz. The 6 MHz frequency was set as a reference to the original default frequency. This can be adjusted later if any issues arise.