### PR TITLE
Enable support for CH347F

### DIFF
--- a/src/ch347jtag.hpp
+++ b/src/ch347jtag.hpp
@@ -33,6 +33,7 @@ class CH347Jtag : public JtagInterface {
  private:
 	bool _verbose;
 	bool _is_largerPack;
+	int _jtagIntf;
 	int setClk(const uint8_t &factor);
 
 	libusb_device_handle *dev_handle;


### PR DESCRIPTION
The CH347F variant has a different PID because it isn't code compatible with the T variant. The bulk interface to target JTAG is different. Rest is the same. 
Fix a Windows issue: libusb_set_auto_detach_kernel_driver is meaningless in Windows and it never return a success code. 