### PR TITLE
dirtyjtag: Allow custom VID/PID via command line options

### DIFF
--- a/src/dirtyJtag.cpp
+++ b/src/dirtyJtag.cpp
@@ -62,7 +62,7 @@ enum dirtyJtagSig {
 	SIG_SRST = (1 << 6)
 };
 
-DirtyJtag::DirtyJtag(uint32_t clkHZ, int8_t verbose):
+DirtyJtag::DirtyJtag(uint32_t clkHZ, int8_t verbose, uint16_t vid, uint16_t pid):
 			_verbose(verbose),
 			dev_handle(NULL), usb_ctx(NULL), _tdi(0), _tms(0)
 {
@@ -73,8 +73,7 @@ DirtyJtag::DirtyJtag(uint32_t clkHZ, int8_t verbose):
 		throw std::exception();
 	}
 
-	dev_handle = libusb_open_device_with_vid_pid(usb_ctx,
-					DIRTYJTAG_VID, DIRTYJTAG_PID);
+	dev_handle = libusb_open_device_with_vid_pid(usb_ctx, vid, pid);
 	if (!dev_handle) {
 		cerr << "fails to open device" << endl;
 		libusb_exit(usb_ctx);

--- a/src/dirtyJtag.hpp
+++ b/src/dirtyJtag.hpp
@@ -19,7 +19,7 @@
 
 class DirtyJtag : public JtagInterface {
  public:
-	DirtyJtag(uint32_t clkHZ, int8_t verbose);
+	DirtyJtag(uint32_t clkHZ, int8_t verbose, uint16_t vid = 0x1209, uint16_t pid = 0xC0CA);
 	virtual ~DirtyJtag();
 
 	int setClkFreq(uint32_t clkHZ) override;

--- a/src/jtag.cpp
+++ b/src/jtag.cpp
@@ -139,7 +139,7 @@ Jtag::Jtag(const cable_t &cable, const jtag_pins_conf_t *pin_conf,
 		break;
 	case MODE_DIRTYJTAG:
 #ifdef ENABLE_DIRTYJTAG
-		_jtag = new DirtyJtag(clkHZ, verbose);
+		_jtag = new DirtyJtag(clkHZ, verbose, cable.vid, cable.pid);
 #else
 		std::cerr << "Jtag: support for dirtyJtag cable was not enabled at compile time" << std::endl;
 		throw std::exception();

--- a/src/xvc_server.cpp
+++ b/src/xvc_server.cpp
@@ -60,7 +60,7 @@ XVC_server::XVC_server(int port, const cable_t & cable,
 			new CH552_jtag(cable.config, dev, serial, clkHZ, _verbose);
 		break;
 	case MODE_DIRTYJTAG:
-		_jtag = new DirtyJtag(clkHZ, _verbose);
+		_jtag = new DirtyJtag(clkHZ, _verbose, cable.vid, cable.pid);
 		break;
 	case MODE_JLINK:
 		_jtag = new Jlink(clkHZ, _verbose);


### PR DESCRIPTION
  ## Summary
  Pass cable.vid and cable.pid to DirtyJtag constructor instead of hardcoded values.

  This allows users to use DirtyJTAG-compatible firmware with custom USB VID/PID:
  openFPGALoader -c dirtyJtag --vid 0x1337 --pid 0x0001 bitstream.fs

  ## Use case
  - Custom DirtyJTAG implementations on embedded MCUs
  - Testing with different VID/PID combinations

  ## Changes
  - `dirtyJtag.hpp`: Add VID/PID parameters with defaults (0x1209:0xC0CA)
  - `dirtyJtag.cpp`: Use passed VID/PID instead of hardcoded defines
  - `jtag.cpp`: Pass cable.vid/pid to constructor
  - `xvc_server.cpp`: Same change for XVC server

  Backward compatible - default VID/PID unchanged.