### PR TITLE
Add workaround for slow JTAG on Sipeed Console

### DIFF
--- a/src/ftdiJtagMPSSE.hpp
+++ b/src/ftdiJtagMPSSE.hpp
@@ -113,6 +113,7 @@ class FtdiJtagMPSSE : public JtagInterface, public FTDIpp_MPSSE {
 	uint8_t _write_mode; /**< write edge configuration */
 	uint8_t _read_mode; /**< read edge configuration */
 	bool _invert_read_edge; /**< read edge selection (false: pos, true: neg) */
+	bool _msb_first; /**< use MSB first, workaround for sipeed console */
 	/* writeTMSTDI specifics */
 	uint32_t _tdo_pos;
 	uint8_t _curr_tdi;


### PR DESCRIPTION
Not sure if I implemented this in the neatest way possible, but at least the logic is here ^^

The MCU on the Sipeed Console apparently has a bug where LSB first mode is incredibly slow (eventually found by comparing wireshark traces between gowin programmer and openfpgaloader). Before this patch it was taking about 4 minutes to program the SRAM of the 138k, with this patch it takes 14 seconds...

