### PR TITLE
Performance improvement for XVC client

### DIFF
--- a/src/xvc_client.cpp
+++ b/src/xvc_client.cpp
@@ -267,18 +267,14 @@ ssize_t XVC_client::xfer_pkt(const string &instr,
 		uint8_t *rx, uint32_t rx_size)
 {
 	ssize_t len = tx_size;
+	vector<uint8_t> buffer(instr.size() + (tx) ? tx_size : 0);
+	memcpy(buffer.data(), instr.c_str(), instr.size());
+	if (tx)
+		memcpy(buffer.data() + instr.size(), tx, tx_size);
 
-	/* 1. instruction */
-	if (sendall(_sock, instr.c_str(), instr.size(), 0) == -1) {
-		printError("Send instruction failed");
+	if (sendall(_sock, buffer.data(), buffer.size(), 0) == -1) {
+		printError("Send failed");
 		return -1;
-	}
-
-	if (tx) {
-		if (sendall(_sock, tx, tx_size, 0) == -1) {
-			printError("Send error");
-			return -1;
-		}
 	}
 
 	if (rx) {


### PR DESCRIPTION
When using the Xilinx Virtual Cable (XVC) client to read a firmware image of about 3 MB from a SPI Flash EEPROM attached to a Xilinx FPGA, the process was very slow (about ten minutes in, only 2.5 % had been read).

I found that this performance could be improved significantly with a very simple change to the client code: Instead of sending the XVC command (`shift:`) and the associated data with two separate calls to `sendall`, with the changes in this PR the command and the data are now merged in a single buffer, so that only a single call of `sendall` is needed.

I found that this improved the performance by a factor of about 200 (!). Instead of (extrapolated) 6.5 hours, the whole image is now read in just 2 minutes. The exact speed-up will of course depend on the network round-trip time and implementation details of the XVC server, but as the change to the client code is so minimal, I think it makes sense to always use this approach.
