### PR TITLE
Add XCKU095 support

### DIFF
--- a/src/part.hpp
+++ b/src/part.hpp
@@ -124,6 +124,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 	{0x13823093, {"xilinx", "kintexus", "xcku035", 6}},
 	{0x13822093, {"xilinx", "kintexus", "xcku040", 6}},
 	{0x13919093, {"xilinx", "kintexus", "xcku060", 6}},
+	{0x23844093, {"xilinx", "kintexus", "xcku095", 6}},
 	{0x1390d093, {"xilinx", "kintexus", "xcku115", 6}},
 
 	/* Xilinx Ultrascale / Virtex */


### PR DESCRIPTION
I verified this by shipping an LED example over to my XCKU095 and it runs correctly.

Before

```
JTAG init failed with: Unknown device with IDCODE: 0x23844093 (manufacturer: 0x049 (Xilinx), part: 0x1c vers: 0x2  
```

After

```
$ sudo openFPGALoader --cable ft232 --detect
empty
Jtag frequency : requested 6.00MHz    -> real 6.00MHz   
index 0:
        idcode 0x23844093
        manufacturer xilinx
        family kintexus
        model  xcku095
        irlength 6
```