### PR TITLE
vivado 2025.2.1 compatibility: add SW_CRC field to bitstream parser

### DIFF
--- a/src/bitparser.cpp
+++ b/src/bitparser.cpp
@@ -109,6 +109,8 @@ int BitParser::parseHeader()
 							_hdr["userId"] = value;
 						} else if (key == "Version") {
 							_hdr["version"] = value;
+						} else if (key == "SW_CRC") {
+							_hdr["crc"] = value;
 						} else {
 							printError("Unknown key " + key);
 							return -1;


### PR DESCRIPTION
A new field, SW_CRC, was added to BIT file headers in Vivado 2025.2.1;  this patch adds it to bitparser.cpp so it doesn't cause an 'Unknown Key' error.