### PR TITLE
bitparser: Relax unknown keys from error to warning

### DIFF
--- a/src/bitparser.cpp
+++ b/src/bitparser.cpp
@@ -112,8 +112,7 @@ int BitParser::parseHeader()
 						} else if (key == "SW_CRC") {
 							_hdr["crc"] = value;
 						} else {
-							printError("Unknown key " + key);
-							return -1;
+							printWarn("Unknown key " + key);
 						}
 					}
 				}

--- a/src/bitparser.cpp
+++ b/src/bitparser.cpp
@@ -111,6 +111,8 @@ int BitParser::parseHeader()
 							_hdr["version"] = value;
 						} else if (key == "SW_CRC") {
 							_hdr["crc"] = value;
+						} else if (key == "COMPRESS") {
+							_hdr["compress"] = value;
 						} else {
 							printWarn("Unknown key " + key);
 						}


### PR DESCRIPTION
I have a couple of bitstreams with the following headers, and was getting an error due to the unknown `COMPRESS` key:
- `sqrl_acorn;COMPRESS=TRUE;UserID=0XFFFFFFFF;Version=2024.1`
- `alibaba_xcku3p;COMPRESS=TRUE;UserID=0XFFFFFFFF;Version=2024.1`

The rejection of unknown keys was added in 63c9741, and has already caused one other issue (#647), so I propose relaxing the error to a warning, in addition to adding the `COMPRESS` key.