### PR TITLE
Enabling the compilation on OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,41 @@ OPENFPGALOADER_SOJ_DIR=/somewhere openFPGALoader xxxx
 `OPENFPGALOADER_SOJ_DIR` must point to directory containing **spiOverJtag**
 bitstreams.
 
+## Disabling uftdi on OpenBSD
+
+Certain evaluation boards can cause the following error when running openFPGAloader on OpenBSD:
+
+```
+fail to read data usb bulk read failed
+JTAG init failed with: low level FTDI init failed
+```
+
+This issue is most likely caused by the uftdi module, trying to access the device. To disable it,
+the following commands can be used:
+
+```bash
+# doas config -e -f -o /bsd.nouftdi /bsd
+OpenBSD 7.8 (GENERIC) #54: Sun Oct 12 12:45:58 MDT 2025
+    deraadt@amd64.openbsd.org:/usr/src/sys/arch/amd64/compile/GENERIC
+Enter 'help' for information
+ukc> disable uftdi*
+356 uftdi* disabled
+ukc> disable uftdi0
+ukc> disable uftdi1
+ukc> quit
+Saving modified kernel.
+# reboot
+```
+
+At the boot prompt, typing in
+
+```
+boot> boot /bsd.nouftdi
+```
+
+will boot the new kernel with the disabled module.
+
+
 ## Sponsors/Partners
 
 ![Sponsors](https://github.com/user-attachments/assets/cb4efce1-ed0c-461c-bd05-9caeb440870d)

--- a/README.md
+++ b/README.md
@@ -156,40 +156,6 @@ OPENFPGALOADER_SOJ_DIR=/somewhere openFPGALoader xxxx
 `OPENFPGALOADER_SOJ_DIR` must point to directory containing **spiOverJtag**
 bitstreams.
 
-## Disabling uftdi on OpenBSD
-
-Certain evaluation boards can cause the following error when running openFPGAloader on OpenBSD:
-
-```
-fail to read data usb bulk read failed
-JTAG init failed with: low level FTDI init failed
-```
-
-This issue is most likely caused by the uftdi module, trying to access the device. To disable it,
-the following commands can be used:
-
-```bash
-# doas config -e -f -o /bsd.nouftdi /bsd
-OpenBSD 7.8 (GENERIC) #54: Sun Oct 12 12:45:58 MDT 2025
-    deraadt@amd64.openbsd.org:/usr/src/sys/arch/amd64/compile/GENERIC
-Enter 'help' for information
-ukc> disable uftdi*
-356 uftdi* disabled
-ukc> disable uftdi0
-ukc> disable uftdi1
-ukc> quit
-Saving modified kernel.
-# reboot
-```
-
-At the boot prompt, typing in
-
-```
-boot> boot /bsd.nouftdi
-```
-
-will boot the new kernel with the disabled module.
-
 
 ## Sponsors/Partners
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ openFPGALoader -- a program to flash FPGA
       --cable-index arg         probe index (FTDI and cmsisDAP)
       --busdev-num arg          select a probe by it bus and device number
                                 (bus_num:device_addr)
-      --ftdi-serial arg         FTDI chip serial number
+      --usb-serial-num arg      USB iSerial (FTDI chip serial number or ESP32
+                                iSerialNumber substring)
+      --ftdi-serial arg         FTDI chip serial number (Deprecated)
       --ftdi-channel arg        FTDI chip channel number (channels 0-3 map to
                                 A-D)
   -d, --device arg              device to use (/dev/ttyUSBx)
@@ -119,6 +121,8 @@ openFPGALoader -- a program to flash FPGA
   -v, --verbose                 Produce verbose output
       --verbose-level arg       verbose level -1: quiet, 0: normal,
                                 1:verbose, 2:debug
+      --force-terminal-mode     force progress bar output as if connected to
+                                a terminal
   -h, --help                    Give this help list
       --verify                  Verify write operation (SPI Flash only)
       --xvc                     Xilinx Virtual Cable Functions
@@ -130,7 +134,8 @@ openFPGALoader -- a program to flash FPGA
   -X, --read-xadc               Read XADC (Xilinx FPGA only)
       --read-register arg       Read Status Register(Xilinx FPGA only)
       --user-flash arg          User flash file (Gowin LittleBee FPGA only)
-  -V, --Version                 Print program version
+  -V, --version                 Print program version
+      --Version                 Print program version (Deprecated)
 
 Mandatory or optional arguments to long options are also mandatory or optional
 for any corresponding short options.
@@ -155,7 +160,6 @@ OPENFPGALOADER_SOJ_DIR=/somewhere openFPGALoader xxxx
 
 `OPENFPGALOADER_SOJ_DIR` must point to directory containing **spiOverJtag**
 bitstreams.
-
 
 ## Sponsors/Partners
 

--- a/doc/guide/troubleshooting.rst
+++ b/doc/guide/troubleshooting.rst
@@ -76,3 +76,37 @@ After changing groups or rules, reload udev rules, then unplug/replug the
 converter and log out/login again.
 
 Reference: `install guide (udev rules section) <https://trabucayre.github.io/openFPGALoader/guide/install.html#udev-rules>`_.
+
+
+Unable to flash device on OpenBSD: `JTAG init failed with: DirtyJtag: fails to open device`
+===========================================================================================
+Certain evaluation boards may show the following error message when running openFPGAloader on OpenBSD:
+
+.. code:: bash
+    fail to read data usb bulk read failed
+    JTAG init failed with: low level FTDI init failed
+
+This issue is most likely caused by the uftdi module, which has already locked the device. 
+Disabling the module can be achieved with the following commands:
+
+.. code:: bash
+    # doas config -e -f -o /bsd.nouftdi /bsd
+    OpenBSD 7.8 (GENERIC) #54: Sun Oct 12 12:45:58 MDT 2025
+        deraadt@amd64.openbsd.org:/usr/src/sys/arch/amd64/compile/GENERIC
+    Enter 'help' for information
+    ukc> disable uftdi*
+    356 uftdi* disabled
+    ukc> disable uftdi0
+    ukc> disable uftdi1
+    ukc> quit
+    Saving modified kernel.
+    # reboot
+
+At the boot prompt, typing in
+
+.. code:: bash
+    boot> boot /bsd.nouftdi
+
+will boot the new kernel with the disabled module. 
+Afterwards, openFPGALoader will access the development board as a generic USB device. 
+

--- a/src/xvc_server.cpp
+++ b/src/xvc_server.cpp
@@ -6,6 +6,7 @@
 #include "xvc_server.hpp"
 
 #include <arpa/inet.h>
+#include <sys/socket.h>
 #include <errno.h>
 #include <netinet/tcp.h>
 #include <unistd.h>


### PR DESCRIPTION
I took the liberty of trying to compile openFPGAloader on OpenBSD. 
After adding one include, ItWorkedOnMyMachine(tm).

I also added a section to the Readme.md file, allowing interested users to disable a problematic module inside the kernel.