### PR TITLE
gowin: fix checksum header key typo

### DIFF
--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -436,7 +436,7 @@ void Gowin::checkCRC()
 	 * is used, try to compare with this value
 	 */
 	try {
-		std::string hdr = _fs->getHeaderVal("checkSum");
+		std::string hdr = _fs->getHeaderVal("CheckSum");
 		if (!hdr.empty()) {
 			if (ucode == strtol(hdr.c_str(), NULL, 16))
 				goto success;


### PR DESCRIPTION
Header key for checksum parsed from gowin *.fs file is accessed incorrectly (mistyped in src/gowin.cpp). 
Should be CheckSum as created in src/fsparser.cpp:96.