### PR TITLE
Efinix: Check for presence of mode header value before checking its value

### DIFF
--- a/src/efinix.cpp
+++ b/src/efinix.cpp
@@ -218,10 +218,13 @@ void Efinix::program(unsigned int offset, bool unprotect_flash)
 					throw std::runtime_error("device mismatch: " + device + " != " + target);
 				}
 			}
-			std::string mode = bit->getHeaderVal("mode");
-			if (mode.find("passive") != std::string::npos) {
-				delete bit;
-				throw std::runtime_error("passive mode not supported for flash");
+			std::map<std::string, std::string> hdr = bit->getHeader();
+			if(hdr.find("mode") != hdr.end()) {
+				std::string mode = bit->getHeaderVal("mode");
+				if (mode.find("passive") != std::string::npos) {
+					delete bit;
+					throw std::runtime_error("passive mode not supported for flash");
+				}
 			}
 		} catch (std::runtime_error& e) {
 			throw;


### PR DESCRIPTION
I must admit that I am not fully aware how raw flashing for efinix is supposed to be handled. But this patch allows flashing of raw files which naturally don't have a "mode" header value at all. This e.g. allows me to flash the Atari ST TOS operating system like so:

` ./openFPGALoader -b trion_t20_bga256 --external-flash -o 0x100000 ./tos104de.img `