### PR TITLE
xilinx: fix to Xilinx::program so a reset is not performed in SPI_MODE when _skip_reset is set

### DIFF
--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -659,7 +659,6 @@ void Xilinx::program(unsigned int offset, bool unprotect_flash)
 		/* Check for BPI flash boards */
 		if (_is_bpi_board) {
 			program_bpi(bit, offset);
-			reset();
 		} else {
 			if (_flash_chips & PRIMARY_FLASH) {
 				select_flash_chip(PRIMARY_FLASH);
@@ -669,8 +668,6 @@ void Xilinx::program(unsigned int offset, bool unprotect_flash)
 				select_flash_chip(SECONDARY_FLASH);
 				program_spi(secondary_bit, _secondary_file_extension, offset, unprotect_flash);
 			}
-
-			reset();
 		}
 	} else {
 		if (_fpga_family == SPARTAN3_FAMILY)
@@ -809,6 +806,9 @@ void Xilinx::program_bpi(ConfigBitstreamParser *bit, unsigned int offset)
 	if (!_bpi_flash->write(offset, data, length)) {
 		throw std::runtime_error("BPI flash programming failed");
 	}
+
+	/* Reset the board if skip_reset is not set */
+	post_flash_access();
 
 	printInfo("BPI flash programming complete");
 }


### PR DESCRIPTION
When writing to the FPGA flash with `--skip-reset` configured on the command line, it was still resetting on completion of the write.

This patch applies a check on `_skip_reset` akin to the check in `Xilinx::post_flash_access` to the `Device::SPI_MODE` path in `Xilinx::program()`.

Testing shows the reset no longer happens and that resets happen as expected in a normal write to memory. It's not clear that there _should_ be two paths to reset (both `post_flash_access` and inside `program()`), but I didn't want to wade into behaviour I didn't fully understand (which indeed I may already have done!).