### PR TITLE
fix BPI flash selection (on ypcb003381p1 board)

### DIFF
--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -1277,6 +1277,18 @@ bool Xilinx::dumpFlash(uint32_t base_addr, uint32_t len)
 
 bool Xilinx::detect_flash()
 {
+	if (_is_bpi_board) {
+		if (!_bpi_flash) {
+			if (!load_bpi_bridge())
+				return false;
+		}
+		if (!_bpi_flash->detect()) {
+			printError("BPI flash detection failed");
+				return false;
+		}
+		return post_flash_access();
+	}
+
 	if (_flash_chips & PRIMARY_FLASH) {
 		select_flash_chip(PRIMARY_FLASH);
 		if (!FlashInterface::detect_flash())


### PR DESCRIPTION
With the YPCB-00338-1P1 board and an HS3 JTAG probe, when I try to detect the flash, the wrong bridge's bitstream is used (`spiOverJtag_xc7k480tffg1156.bit.gz` instead of `bpiOverJtag_xc7k480tffg1156.bit.gz`):

```
$ openFPGALoader -b ypcb003381p1 -c digilent_hs3 --detect -f
write to flash
Jtag frequency : requested 6.00MHz    -> real 6.00MHz   
Detect flash:
Error: fail to open /home/denis/FPGA/ECP5stuff/share/openFPGALoader/spiOverJtag_xc7k480tffg1156.bit.gz
terminate called after throwing an instance of 'std::runtime_error'
  what():  Error: fail to open /home/denis/FPGA/ECP5stuff/share/openFPGALoader/spiOverJtag_xc7k480tffg1156.bit.gz
```
This PR fixes the issue by checking `_is_bpi_board`, and the flash is then detected correctly:
```
$ openFPGALoader -b ypcb003381p1 -c digilent_hs3 --detect -f
write to flash
Jtag frequency : requested 6.00MHz    -> real 6.00MHz   
Use: /home/denis/FPGA/ECP5stuff/share/openFPGALoader/bpiOverJtag_xc7k480tffg1156.bit.gz
load program
Load SRAM: [==================================================] 100.00%
Done
Shift IR 35
ir: 1 isc_done 1 isc_ena 0 init 1 done 1
Detecting BPI flash...
Intel/Micron flash detected
Manufacturer ID: 0x0089
Device ID: 0x887e
Flash capacity: 64 MB (512 Mbit)
```