### PR TITLE
Add --version lowercase flag to comply with convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ openFPGALoader -- a program to flash FPGA
   -v, --verbose                 Produce verbose output
       --verbose-level arg       verbose level -1: quiet, 0: normal,
                                 1:verbose, 2:debug
+      --force-terminal-mode     force progress bar output as if connected to
+                                a terminal
   -h, --help                    Give this help list
       --verify                  Verify write operation (SPI Flash only)
       --xvc                     Xilinx Virtual Cable Functions
@@ -130,7 +132,8 @@ openFPGALoader -- a program to flash FPGA
   -X, --read-xadc               Read XADC (Xilinx FPGA only)
       --read-register arg       Read Status Register(Xilinx FPGA only)
       --user-flash arg          User flash file (Gowin LittleBee FPGA only)
-  -V, --Version                 Print program version
+  -V, --version                 Print program version
+      --Version                 Print program version (Deprecated)
 
 Mandatory or optional arguments to long options are also mandatory or optional
 for any corresponding short options.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1027,7 +1027,8 @@ int parse_opt(int argc, char **argv, struct arguments *args,
 				cxxopts::value<std::string>(args->read_register))
 			("user-flash", "User flash file (Gowin LittleBee FPGA only)",
 				cxxopts::value<std::string>(args->user_flash))
-			("V,Version", "Print program version");
+			("V,version", "Print program version")
+			("Version", "Print program version (Deprecated)");
 
 		options.parse_positional({"bitstream"});
 		auto result = options.parse(argc, argv);
@@ -1055,7 +1056,7 @@ int parse_opt(int argc, char **argv, struct arguments *args,
 			args->verbose = verbose_level;
 		}
 
-		if (result.count("Version")) {
+		if (result.count("Version") || result.count("version")) {
 			std::cout << "openFPGALoader " << VERSION << std::endl;
 			return 1;
 		}


### PR DESCRIPTION
Extremely minor improvement, but nearly all program support `<program> --version` to get the version. Supporting `--Version` as titlecase "Version" is good, but supporting the far-more-standard `--version` would be nice.