### PR TITLE
Fix incorrect handling of spaces and newlines in SVF bitstreams and add progressbar

### DIFF
--- a/src/svf_jtag.cpp
+++ b/src/svf_jtag.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "jtag.hpp"
+#include "progressBar.hpp"
 
 
 void SVF_jtag::split_str(std::string const &str, std::vector<std::string> &vparse)
@@ -379,6 +380,14 @@ void SVF_jtag::parse(std::string filename)
 		return;
 	}
 	unsigned int lineno = 0;
+	int lines_total = std::count(std::istreambuf_iterator<char>(fs),
+             std::istreambuf_iterator<char>(), '\n') + 1;
+	fs.clear();
+	fs.seekg(0,std::ios::beg);
+	printf("Reading %s with %d lines", filename.c_str(), lines_total);
+
+	ProgressBar progress("Writing SVF " + filename, lines_total, 50, _verbose);
+
 	try	{
 		while (getline(fs, str)) {
 			if(str.empty()){
@@ -409,13 +418,16 @@ void SVF_jtag::parse(std::string filename)
 				handle_instruction(vstr);
 				vstr.clear();
 			}
+			progress.display(lineno);
 		}
 	}
 	catch (std::exception &e)
 	{
-		std::cerr << "Cannot proceed because of error(s) at line " << lineno << std::endl;
+		std::cerr << "Cannot proceed because of error(s) at line " << std::dec << lineno << std::endl;
+		progress.fail();
 		throw;
 	}
 
+	progress.done();
 	std::cout << "end of SVF file" << std::endl;
 }

--- a/src/svf_jtag.cpp
+++ b/src/svf_jtag.cpp
@@ -7,6 +7,7 @@
 
 #include "svf_jtag.hpp"
 
+#include <stdexcept>
 #include <unistd.h>
 
 #include <algorithm>
@@ -23,8 +24,11 @@ void SVF_jtag::split_str(std::string const &str, std::vector<std::string> &vpars
 {
 	std::string token;
 	std::istringstream tokenStream(str);
-	while (getline(tokenStream, token, ' '))
-		vparse.push_back(token);
+	while (tokenStream >> token){
+		if(!token.empty()){
+			vparse.push_back(token);
+		}
+	}
 }
 
 void SVF_jtag::clear_XYR(svf_XYR &t)
@@ -89,6 +93,11 @@ void SVF_jtag::parse_XYR(std::vector<std::string> const &vstr, svf_XYR &t)
 		return;
 	for (size_t pos = 2; pos < vstr.size(); pos++) {
 		s = vstr[pos];
+
+		if (s.empty()){
+			throw std::runtime_error("Error parsing instruction: extraneous spaces");
+			return;
+		}
 
 		if (!s.compare("TDO")) {
 			mode = 1;
@@ -372,6 +381,9 @@ void SVF_jtag::parse(std::string filename)
 	unsigned int lineno = 0;
 	try	{
 		while (getline(fs, str)) {
+			if(str.empty()){
+				continue;
+			}
 			/* sanity check: DOS CR */
 			if (str.back() == '\r')
 				str.pop_back();


### PR DESCRIPTION
Added some missing checks regarding newlines and spaces in SVF files (specifically in svf_jtag.cpp) which, when not present, would cause `SVF_jtag::split_str` to yield such characters when parsing certain malformed SVF bitstreams, crashing the program with `SEGFAULT` and failed assertions on `.empty()` in string vectors.

Also implemented a `ProgressBar` for reading SVF bitstreams.