### PR TITLE
xilinx: add BPI parallel NOR support to dumpFlash()

### DIFF
--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -841,6 +841,35 @@ void Xilinx::program_bpi(ConfigBitstreamParser *bit, unsigned int offset)
 	printInfo("BPI flash programming complete");
 }
 
+bool Xilinx::dumpFlash_bpi(uint32_t base_addr, uint32_t len)
+{
+	if (!_bpi_flash) {
+		if (!load_bpi_bridge())
+			return false;
+	}
+	if (!_bpi_flash->detect()) {
+		printError("BPI flash detection failed");
+		return false;
+	}
+	if (len == 0)
+		len = _bpi_flash->capacity();
+	std::vector<uint8_t> buf(len);
+	printInfo("Reading BPI flash (slow, one word per USB round-trip)...");
+	if (!_bpi_flash->read(buf.data(), base_addr, len)) {
+		printError("BPI Flash read failed");
+		return false;
+	}
+	FILE *fd = fopen(_filename.c_str(), "wb");
+	if (!fd) {
+		printError("Can't open dump file");
+		return false;
+	}
+	fwrite(buf.data(), 1, len, fd);
+	fclose(fd);
+	printSuccess("BPI dump DONE");
+	return post_flash_access();
+}
+
 float Xilinx::get_spiOverJtag_version()
 {
 	uint8_t jtx[6] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00};
@@ -1254,6 +1283,10 @@ void Xilinx::displayRegister(const std::string reg_name, const uint32_t reg_val)
 
 bool Xilinx::dumpFlash(uint32_t base_addr, uint32_t len)
 {
+	/* BPI parallel NOR dump (added: upstream dumpFlash lacks a BPI path) */
+	if (_is_bpi_board)
+		return dumpFlash_bpi(base_addr, len);
+
 	if (_fpga_family == XC95_FAMILY || _fpga_family == XCF_FAMILY) {
 		std::string buffer;
 		if (_fpga_family == XC95_FAMILY) {

--- a/src/xilinx.hpp
+++ b/src/xilinx.hpp
@@ -39,6 +39,7 @@ class Xilinx: public Device, FlashInterface {
 		void program_bpi(ConfigBitstreamParser * bit, unsigned int offset);
 		void program_mem(ConfigBitstreamParser *bitfile);
 		bool dumpFlash(uint32_t base_addr, uint32_t len) override;
+		bool dumpFlash_bpi(uint32_t base_addr, uint32_t len);
 
 		bool read_register(const std::string reg_name) override {
 			displayRegister(reg_name, dumpRegister(reg_name));


### PR DESCRIPTION
## Summary
- BPI (parallel CFI NOR) flash support was added in #676 for `program_bpi`/write, but `Xilinx::dumpFlash()` only handles the XC95/XCF and SPI (`PRIMARY_FLASH`/`SECONDARY_FLASH`) paths.
- On boards where `_is_bpi_board` is set, `--dump-flash` currently falls through to the SPI `FlashInterface`, silently producing garbage instead of reading the BPI NOR.
- This adds a BPI branch mirroring the existing write path: load the BPI JTAG bridge if needed, `detect()` the flash, `read()` the requested region, and write it to the output file.

## Test plan
Tested on real hardware: a Kintex-7 XC7K480T board with a Micron MT28GU512AAA1EGC BPI NOR, via a Digilent HS2 cable (`-c digilent_hs2 -b <board>`).

- [x] Wrote a block of random data to a scratch flash region with `--write-flash -o <offset>`.
- [x] Read the same region back with the patched `--dump-flash -o <offset> --file-size <len>`.
- [x] Confirmed the written and read-back files are byte-identical (`cmp`).
- [x] `dumpFlash()` correctly calls `load_bpi_bridge()` when `_bpi_flash` isn't already loaded, and `post_flash_access()` to restore JTAG state afterward, matching the pattern used elsewhere in the BPI write path.

Note: BPI reads are one word per USB round-trip (no burst read in `BPIFlash::read()`), so large dumps are slow — this PR doesn't change that, it just makes `--dump-flash` functional for BPI boards.