### PR TITLE
boards: add ALINX AXKU095 (XCKU095-FFVA1156)

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -34,6 +34,13 @@
   Memory: OK
   Flash: OK
 
+- ID: alinx_axku095
+  Description: ALINX AXKU095 Kintex UltraScale FPGA Dev Board
+  URL: https://www.en.alinx.com/Product/FPGA-Development-Boards/Kintex-UltraScale/AXKU095.html
+  FPGA: Kintex UltraScale xcku095-ffva1156
+  Memory: OK
+  Flash: OK
+
 - ID: atumA3Nano
   Description: Terasic Atum A3 Nano
   URL: https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&No=1373

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -124,6 +124,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("alinx_ax7102",    "xc7a100tfgg484",       "",             SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("alinx_ax7201",    "xc7a200tfbg484",       "",             SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("alinx_ax7203",    "xc7a200tfbg484",       "",             SPI_FLASH, 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("alinx_axku095",   "xcku095-ffva1156",    "digilent_hs2", SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("antmicro_ddr4_tester", "xc7k160tffg676",  "ft4232",       SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("antmicro_ddr5_tester", "xc7k160tffg676",  "ft4232",       SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("antmicro_lpddr4_tester", "xc7k70tfbg484", "ft4232",       SPI_FLASH, 0, 0, CABLE_DEFAULT),


### PR DESCRIPTION
Add board preset for the Alinx AXKU095 Kintex UltraScale dev board, using the Digilent HS2 cable (FT232H). Tested JTAG detect and SRAM programming with IDCODE 0x23844093.

https://www.en.alinx.com/Product/FPGA-Development-Boards/Kintex-UltraScale/AXKU095.html

there are two other boards of exactly the same form factor, I imagine it is relativity easy to include them, however i do not have access to them so i can not verify them, I have only physically verified it on the AXKU095 


https://www.en.alinx.com/Product/FPGA-Development-Boards/Kintex-UltraScale/AXKU062.html
XCKU060-2FFVA1156I

https://www.en.alinx.com/Product/FPGA-Development-Boards/Kintex-UltraScale/AXKU042.html
XCKU040-2FFVA1156I