### PR TITLE
Support programming Max10 10M50D with .pof

### DIFF
--- a/src/altera.cpp
+++ b/src/altera.cpp
@@ -372,6 +372,15 @@ const std::map<uint32_t, Altera::max10_mem_t> Altera::max10_memory_map = {
 		.done_bit_addr = 0x0011,  // done bit
 		.pgm_success_addr = 0x0015}  // program success addr
 	},
+	{0x31050dd, { // 10M50D
+		.check_addr0 = 0x80009,  // check_addr0
+		.dsm_addr = 0x0000, .dsm_len = 2048,  // DSM
+		.ufm_addr = 0x0800, .ufm_len = {8192, 8192},  // UFM
+		.cfm_addr = 0x2400, .cfm_len = {172032, 73728, 98304},  // CFM
+		.sectors_erase_addr = {0x17ffff, 0x27ffff, 0x37ffff, 0x47ffff, 0x57ffff}, // sectors erase address
+		.done_bit_addr = 0x0015,  // done bit
+		.pgm_success_addr = 0x0015}  // program success addr
+	},
 };
 
 /* Write an arbitrary file in UFM1, UFM0 by default and also CFM2 and CFM1 if


### PR DESCRIPTION
I'm not 100% confident I got all these constants correct, but I sourced DSM/UFM/CFM addresses and sizes from this [svf2isc](https://docs.altera.com/search?content-lang=en-US&query=IEEE+1532&value-filters=Resource_Type~%2522Developer+Resources%257CModels%257CBSDL+Models%2522*device_family~%2522Device+Families%257CMAX+Families%257CMAX+10%2522&sort=relevance) script, and to get `done_bit_addr` I cross referenced the FLOW_PROGRAM_DONEBIT from different MAX10 [BSDL files](https://docs.altera.com/search?content-lang=en-US&query=IEEE+1532&value-filters=Resource_Type~%2522Developer+Resources%257CModels%257CBSDL+Models%2522*device_family~%2522Device+Families%257CMAX+Families%257CMAX+10%2522&sort=relevance) and found the same address as the 10M25SA (but I don't know how this value was originally obtained---for documentation purposes it would be helpful if someone could comment in this PR about how this value is found).