### PR TITLE
Fix XVC error "Invalid DAP ACK value: 3"

### DIFF
--- a/src/ftdiJtagMPSSE.cpp
+++ b/src/ftdiJtagMPSSE.cpp
@@ -410,6 +410,7 @@ int32_t FtdiJtagMPSSE::update_tms_buff(uint8_t *buffer, uint8_t bit,
 		uint8_t tdo_tmp;
 		if ((ret = mpsse_read(&tdo_tmp, 1)) < 0)
 			return ret;
+		tdo_tmp >>= (8 - offset);
 		update_tdo_buff(&tdo_tmp, tdo, offset);
 		offset = 0;
 		buffer[0] = 0;


### PR DESCRIPTION
Currently when using `openFPGALoader --xvc`, I get the following error when enumerating JTAG targets in `xsdb` with a Zynq UltraScale+ MPSoC [AUP-ZU3](https://github.com/trabucayre/openFPGALoader/issues/210#issuecomment-1443401890) devkit:

```
xsdb% targets
  1  PS TAP
     2  PMU
     3  PL
  4  DAP (Cannot open JTAG port: Invalid DAP ACK value: 3)
```

Another user seems to have run into the [exact same issue](https://github.com/trabucayre/openFPGALoader/issues/210#issuecomment-1443401890) a while ago.

It's not clear to me what exact conditions are necessary to trigger this bug, but I noticed that `writeTDI` [performs realignment](https://github.com/trabucayre/openFPGALoader/issues/210#issuecomment-1443401890) after `mpsse_read` but `writeTMSTDI` doesn't; adding this realignment fixes the issue for me.