### PR TITLE
Add WSL Instructions

### DIFF
--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -12,7 +12,7 @@ Debian/Ubuntu
 openFPGALoader is available in the default repositories:
 
 .. code-block:: bash
-    
+
     sudo apt install openfpgaloader
 
 Guix
@@ -59,7 +59,7 @@ openFPGALoader is available as a Copr repository:
     sudo dnf copr enable mobicarte/openFPGALoader
     sudo dnf install openFPGALoader
 
-From source 
+From source
 ----------------------------
 
 This application uses ``libftdi1``, so this library must be installed (and, depending on the distribution, headers too):
@@ -217,6 +217,31 @@ Alternatively, if you want to build it by hand:
 
 Windows
 =======
+
+WSL
+---
+
+.. code-block:: bash
+
+    sudo apt install \
+      mingw-w64 \
+      libz-mingw-w64-dev \
+      clang \
+      lld \
+      cmake \
+      pkg-config \
+      p7zip-full
+
+    cmake -S . -B build-win64-cross \
+        -DCMAKE_TOOLCHAIN_FILE="$PWD/cmake/Toolchain-x86_64-w64-mingw32.cmake" \
+        -DWINDOWS_CROSSCOMPILE=ON \
+        -DCROSS_COMPILE_DEPS=ON \
+        -DCMAKE_BUILD_TYPE=Release
+
+    cmake --build build-win64-cross --parallel "$(nproc)"
+
+    file build-win64-cross/openFPGALoader.exe
+
 
 MSYS2 (Native Build)
 --------------------


### PR DESCRIPTION
Adds WSL (Windows Subsystem for Linux) instructions.

Since WSL failed to build with the current instructions: with this error

```
gojimmypi:/mnt/c/workspace/openFPGALoader/build-win64
$ cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-x86_64-w64-mingw32.cmake ..
-- The CXX compiler identification is GNU 10.0.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/x86_64-w64-mingw32-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
-- Checking for module 'libftdi1'
--   Found libftdi1, version 1.5
-- Checking for module 'libusb-1.0'
--   Found libusb-1.0, version 1.0.25
-- Checking for module 'hidapi-libusb'
--   No package 'hidapi-libusb' found
-- Checking for module 'hidapi-hidraw'
--   No package 'hidapi-hidraw' found
-- Checking for module 'hidapi'
--   No package 'hidapi' found
-- Checking for module 'zlib'
--   Found zlib, version 1.2.11
CologneChip support enabled
Efinix support enabled
ICE40 support enabled
Lattice SSPI support enabled
Altera support enabled
Anlogic support enabled
Gowin support enabled
Xilinx support enabled
Lattice support enabled
Anlogic Cable support enabled
CH347 support enabled
hidapi-libusb not found: cmsis_dap v1 support disabled
cmsis_dap v1 support disabled
cmsis_dap v2 support enabled
DFU support enabled
dirtyJtag support enabled
ESP32S3 support enabled
Gowin GWU2X support enabled
JLink support enabled
Remote bitbang client support disabled
Xilinx Platform Cable USB (XPCU) support enabled
Xilinx Virtual Client support disabled
Xilinx Virtual Server support disabled
-- Configuring done (2.7s)
-- Generating done (0.0s)
-- Build files have been written to: /mnt/c/workspace/openFPGALoader/build-win64
gojimmypi:/mnt/c/workspace/openFPGALoader/build-win64
$ cmake --build . --parallel
[  1%] Building CXX object CMakeFiles/openFPGALoader.dir/src/common.cpp.obj
[  3%] Building CXX object CMakeFiles/openFPGALoader.dir/src/configBitstreamParser.cpp.obj
[  5%] Building CXX object CMakeFiles/openFPGALoader.dir/src/device.cpp.obj
[  7%] Building CXX object CMakeFiles/openFPGALoader.dir/src/display.cpp.obj
[  9%] Building CXX object CMakeFiles/openFPGALoader.dir/src/main.cpp.obj
[ 13%] Building CXX object CMakeFiles/openFPGALoader.dir/src/progressBar.cpp.obj
[ 13%] Building CXX object CMakeFiles/openFPGALoader.dir/src/rawParser.cpp.obj
[ 15%] Building CXX object CMakeFiles/openFPGALoader.dir/src/jedParser.cpp.obj
[ 16%] Building CXX object CMakeFiles/openFPGALoader.dir/src/mcsParser.cpp.obj
In file included from /usr/include/features.h:392,
                 from /usr/include/unistd.h:25,
                 from /mnt/c/workspace/openFPGALoader/src/display.cpp:6:
/usr/include/features-time64.h:20:10: fatal error: bits/wordsize.h: No such file or directory
   20 | #include <bits/wordsize.h>
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
In file included from /usr/lib/gcc/x86_64-w64-mingw32/10-win32/include/c++/cwchar:44,
                 from /usr/lib/gcc/x86_64-w64-mingw32/10-win32/include/c++/bits/postypes.h:40,
                 from /usr/lib/gcc/x86_64-w64-mingw32/10-win32/include/c++/iosfwd:40,
                 from /usr/lib/gcc/x86_64-w64-mingw32/10-win32/include/c++/ios:38,
                 from /usr/lib/gcc/x86_64-w64-mingw32/10-win32/include/c++/ostream:38,
                 from /usr/lib/gcc/x86_64-w64-mingw32/10-win32/include/c++/iostream:39,
                 from /mnt/c/workspace/openFPGALoader/src/configBitstreamParser.cpp:6:
/usr/include/wchar.h:27:10: fatal error: bits/libc-header-start.h: No such file or directory
   27 | #include <bits/libc-header-start.h>

[ ... snip many more errors ... ]

/usr/include/wchar.h:27:10: fatal error: bits/libc-header-start.h: No such file or directory
   27 | #include <bits/libc-header-start.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/openFPGALoader.dir/build.make:197: CMakeFiles/openFPGALoader.dir/src/mcsParser.cpp.obj] Error 1
compilation terminated.
gmake[2]: *** [CMakeFiles/openFPGALoader.dir/build.make:167: CMakeFiles/openFPGALoader.dir/src/rawParser.cpp.obj] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/openFPGALoader.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
gojimmypi:/mnt/c/workspace/openFPGALoader/build-win64
```