### PR TITLE
Add Altera Cyclone II device IDs.

### DIFF
--- a/src/part.hpp
+++ b/src/part.hpp
@@ -248,6 +248,7 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 
 	/* Altera Cyclone II/III/IV/10 LP */
 	{0x020b10dd, {"altera", "cyclone II",           "EP2C5",                         10}},
+	{0x020b40dd, {"altera", "cyclone II",           "EP2C35",                        10}},
 	{0x020f10dd, {"altera", "cyclone III/IV/10 LP", "EP3C5/EP3C10/EP4CE6/EP4CE10",   10}},
 	{0x020f20dd, {"altera", "cyclone III/IV/10 LP", "EP3C16/EP4CE15/10CL016",        10}},
 	{0x020f30dd, {"altera", "cyclone III/IV/10 LP", "EP3C25/EP4CE22/10CL025",        10}},

--- a/src/part.hpp
+++ b/src/part.hpp
@@ -248,7 +248,12 @@ static std::map <uint32_t, fpga_model> fpga_list = {
 
 	/* Altera Cyclone II/III/IV/10 LP */
 	{0x020b10dd, {"altera", "cyclone II",           "EP2C5",                         10}},
+	{0x020b20dd, {"altera", "cyclone II",           "EP2C8",                         10}},
+	{0x020b30dd, {"altera", "cyclone II",           "EP2C15",                        10}},
+	{0x020b30dd, {"altera", "cyclone II",           "EP2C20",                        10}},
 	{0x020b40dd, {"altera", "cyclone II",           "EP2C35",                        10}},
+	{0x020b50dd, {"altera", "cyclone II",           "EP2C50",                        10}},
+	{0x020b60dd, {"altera", "cyclone II",           "EP2C70",                        10}},
 	{0x020f10dd, {"altera", "cyclone III/IV/10 LP", "EP3C5/EP3C10/EP4CE6/EP4CE10",   10}},
 	{0x020f20dd, {"altera", "cyclone III/IV/10 LP", "EP3C16/EP4CE15/10CL016",        10}},
 	{0x020f30dd, {"altera", "cyclone III/IV/10 LP", "EP3C25/EP4CE22/10CL025",        10}},


### PR DESCRIPTION
As listed on Table 3–3. 32-Bit Cyclone II Device IDCODE, from Cyclone II Device Handbook, Volume 1.

This enables upload of SVF files to Altera/Terasic DE2 educational boards (legacy, but still useful).

Tested EP2C35 on the DE2. Others untested.