### PR TITLE
Fix logic errors on _backend identification.

### DIFF
--- a/src/cmsisDAP.cpp
+++ b/src/cmsisDAP.cpp
@@ -200,19 +200,37 @@ CmsisDAP::CmsisDAP(const cable_t &cable, int index, uint32_t clkHZ, int8_t verbo
 	}
 
 	if (is_error) {
-		if (BACKEND_HID) {
-			hid_close(_hid_dev);
-			hid_exit();
-		} else {
-			libusb_close(_usb_dev);
-			libusb_exit(_ctx);
+		switch(_backend){
+#ifdef ENABLE_CMSISDAP_V1
+			case BACKEND_HID:
+				hid_close(_hid_dev);
+				hid_exit();
+				break;
+#endif
+#ifdef ENABLE_CMSISDAP_V2
+			case BACKEND_USBBULK:
+				libusb_close(_usb_dev);
+				libusb_exit(_ctx);
+				break;
+#endif
+			default:
+				break;
 		}
 		throw std::runtime_error("cmsisDAP: init Failed");
 	} else {
-		if (BACKEND_HID) {
-			printInfo("HID init successful");
-		} else {
-			printInfo("USB bulk init successful");
+		switch(_backend){
+#ifdef ENABLE_CMSISDAP_V1
+			case BACKEND_HID:
+				printInfo("HID init successful");
+				break;
+#endif
+#ifdef ENABLE_CMSISDAP_V2
+			case BACKEND_USBBULK:
+				printInfo("USB bulk init successful");
+				break;
+#endif
+			default:
+				break;
 		}
 	}
 	if (clkHZ > 0)


### PR DESCRIPTION
I got the compile error below, and went to check the sources. Turns out there was a logic error on backed type detection. Just patched the code following the pattern on the rest of the file.

IMHO that many switch(...) inside a class feels dirty. Maybe refactor backends as a separate classes?

```
/tmp/openFPGALoader/src/cmsisDAP.cpp: In constructor ‘CmsisDAP::CmsisDAP(const cable_t&, int, uint32_t, int8_t)’:
/tmp/openFPGALoader/src/cmsisDAP.cpp:204:35: error: ‘_hid_dev’ was not declared in this scope
  204 |                         hid_close(_hid_dev);
      |                                   ^~~~~~~~
/tmp/openFPGALoader/src/cmsisDAP.cpp:204:25: error: ‘hid_close’ was not declared in this scope
  204 |                         hid_close(_hid_dev);
      |                         ^~~~~~~~~
/tmp/openFPGALoader/src/cmsisDAP.cpp:205:25: error: ‘hid_exit’ was not declared in this scope
  205 |                         hid_exit();
      |                         ^~~~~~~~
```