### PR TITLE
Fix CMSIS-DAP packet sizes for Atmel programmers

### DIFF
--- a/src/cmsisDAP.cpp
+++ b/src/cmsisDAP.cpp
@@ -99,6 +99,29 @@ enum cmsisdap_backend_type {
 	BACKEND_USBBULK = 1,
 };
 
+/* Some third-gen Atmel/Microchip EDBG-based tools enumerate as ordinary
+ * CMSIS-DAP HID devices but actually use a 512 byte HID report size
+ * instead of the CMSIS-DAP default of 64 bytes. Keep track of those
+ * quirks here.
+ */
+struct hid_report_size_quirk {
+	uint16_t vid;
+	uint16_t pid;
+	uint16_t report_size;
+};
+
+static const struct hid_report_size_quirk hid_report_size_quirks[] = {
+	{0x03eb, 0x2140, 512},  // Atmel JTAG-ICE 3
+	{0x03eb, 0x2141, 512},  // Atmel-ICE
+	{0x03eb, 0x2144, 512},  // Atmel Power Debugger
+	{0x03eb, 0x2111, 512},  // EDBG (found on Xplained Pro boards)
+	{0x03eb, 0x2157, 512},  // Zero (???)
+	{0x03eb, 0x2169, 512},  // EDBG with Mass Storage (Xplained Pro boards)
+	{0x03eb, 0x216a, 512},  // Commercially available EDBG (third-party use)
+	{0x03eb, 0x2170, 512},  // Kraken (???)
+	{0, 0, 0}
+};
+
 CmsisDAP::CmsisDAP(const cable_t &cable, int index, uint32_t clkHZ, int8_t verbose):_verbose(verbose>0),
 		_device_idx(0),  _vid(cable.vid), _pid(cable.pid), _serial_number(L""),
 #ifdef ENABLE_CMSISDAP_V1
@@ -247,6 +270,31 @@ CmsisDAP::~CmsisDAP()
 		free(_ll_buffer);
 }
 
+/* apply known report-size quirks *before* any communication is
+ * attempted: the INFO_ID_MAX_PKT_SZ probe below relies on
+ * transactions already being correctly framed, which isn't the
+ * case for quirky devices until _pkt_sz is fixed up here.
+ */
+bool CmsisDAP::applyQuirk()
+{
+	for (const struct hid_report_size_quirk *q = &hid_report_size_quirks[0]; q->vid != 0; q++) {
+		if (q->vid == _vid && q->pid == _pid) {
+			_pkt_sz = q->report_size;
+			break;
+		}
+	}
+	if (_pkt_sz + 1 > 1024) {
+		unsigned char *tmp = (unsigned char *)realloc(_ll_buffer, _pkt_sz + 1);
+		if (!tmp) {
+			printError("internal buffer reallocation failed");
+			return false;
+		}
+		_ll_buffer = tmp;
+		_buffer = _ll_buffer + 2;
+	}
+	return true;
+}
+
 #ifdef ENABLE_CMSISDAP_V1
 bool CmsisDAP::initWithHID(const cable_t &cable, int index, int8_t verbose){
 		std::vector<struct hid_device_info *> dev_found;
@@ -328,6 +376,10 @@ bool CmsisDAP::initWithHID(const cable_t &cable, int index, int8_t verbose){
 	}
 	/* cleanup enumeration */
 	hid_free_enumeration(devs);
+
+	/* quirk handling */
+	if (!applyQuirk())
+		return false;
 
 	/* query actual HID packet size and grow buffer if needed */
 	uint8_t buf[65];

--- a/src/cmsisDAP.cpp
+++ b/src/cmsisDAP.cpp
@@ -248,6 +248,29 @@ CmsisDAP::~CmsisDAP()
 }
 
 #ifdef ENABLE_CMSISDAP_V1
+/* Some third-gen Atmel/Microchip EDBG-based tools enumerate as ordinary
+ * CMSIS-DAP HID devices but actually use a 512 byte HID report size
+ * instead of the CMSIS-DAP default of 64 bytes. Keep track of those
+ * quirks here.
+ */
+struct hid_report_size_quirk {
+	uint16_t vid;
+	uint16_t pid;
+	uint16_t report_size;
+};
+
+static const struct hid_report_size_quirk hid_report_size_quirks[] = {
+	{0x03eb, 0x2140, 512},  // Atmel JTAG-ICE 3
+	{0x03eb, 0x2141, 512},  // Atmel-ICE
+	{0x03eb, 0x2144, 512},  // Atmel Power Debugger
+	{0x03eb, 0x2111, 512},  // EDBG (found on Xplained Pro boards)
+	{0x03eb, 0x2157, 512},  // Zero (???)
+	{0x03eb, 0x2169, 512},  // EDBG with Mass Storage (Xplained Pro boards)
+	{0x03eb, 0x216a, 512},  // Commercially available EDBG (third-party use)
+	{0x03eb, 0x2170, 512},  // Kraken (???)
+	{0, 0, 0}
+};
+
 bool CmsisDAP::initWithHID(const cable_t &cable, int index, int8_t verbose){
 		std::vector<struct hid_device_info *> dev_found;
 
@@ -328,6 +351,26 @@ bool CmsisDAP::initWithHID(const cable_t &cable, int index, int8_t verbose){
 	}
 	/* cleanup enumeration */
 	hid_free_enumeration(devs);
+
+	/* apply known report-size quirks *before* any communication is
+	 * attempted: the INFO_ID_MAX_PKT_SZ probe below relies on
+	 * transactions already being correctly framed, which isn't the
+	 * case for quirky devices until _pkt_sz is fixed up here.
+	 */
+	for (int i = 0; hid_report_size_quirks[i].vid != 0; i++) {
+		if (hid_report_size_quirks[i].vid == _vid &&
+				hid_report_size_quirks[i].pid == _pid) {
+			_pkt_sz = hid_report_size_quirks[i].report_size;
+			break;
+		}
+	}
+	if (_pkt_sz + 1 > 1024) {
+		unsigned char *tmp = (unsigned char *)realloc(_ll_buffer, _pkt_sz + 1);
+		if (!tmp)
+			throw std::runtime_error("internal buffer reallocation failed");
+		_ll_buffer = tmp;
+		_buffer = _ll_buffer + 2;
+	}
 
 	/* query actual HID packet size and grow buffer if needed */
 	uint8_t buf[65];

--- a/src/cmsisDAP.hpp
+++ b/src/cmsisDAP.hpp
@@ -125,6 +125,9 @@ class CmsisDAP: public JtagInterface {
 		int writeJtagSequence(uint8_t tms, const uint8_t *tx, uint8_t *rx,
 				uint32_t len, bool end);
 
+		/* apply quirk for some specifics probes */
+		bool applyQuirk();
+
 		bool _verbose;                /**< display more message */
 		int16_t _device_idx;          /**< device index */
 		uint16_t _vid;                /**< device Vendor ID */


### PR DESCRIPTION
The CMSIS-DAP backend does not work with certain Atmel/Microchip debuggers (constant timeouts, responses for earlier queries being returned for later ones).

```
% openFPGALoader --fpga-part xc7k480tffg1156 --cable cmsisdap --vid 0x03EB --pid 0x2141 --detect -vvv
Cable VID overridden
Cable PID overridden
cmsisDAP: failed to find compatible CMSIS-DAP v2 device
cmsisDAP v2: try USB bulk init but failed
Found 1 compatible device:
    0x03eb 0x2141 0x0 Atmel-ICE CMSIS-DAP
Error: HID read timeout

    VID: 03eb
Error: HID read timeout

    PID: 2141
Error: HID read timeout

    serial number: J427000xxxxx
Error: HID read timeout

    firmware version : NA
Error: HID read timeout

    target device vendor: Atmel Corp.
Error: HID read timeout

    target device name: Atmel-ICE CMSIS-DAP
Error: HID read timeout

    hardware capabilities : NA
Error: HID read timeout

    SWO trace buffer size : NA
Error: Waiting for 1Byte received 20
00 14 41 74 6d 65 6c 2d 49 43 45 20 43 4d 53 49 53 2d 44 41 50 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
Error: HID read timeout

    max packet size : NA
Error: HID read timeout

Hardware cap f0 00 00
JTAG is not supported by the probe
```

Apparently, some Atmel tools use a nonstandard report size, which wreaks all kinds of havoc on the CMSIS-DAP backend. OpenOCD handles this with a [table](https://github.com/openocd-org/openocd/blob/da3920b0a52dc2d394afb222c688dac7e57acc1b/src/jtag/drivers/cmsis_dap_usb_hid.c#L43) of offending VID/PIDs, allowing the initial communication to proceed correctly even before packet sizes can be queried. This fix simply sets `_pkt_sz` in advance if the user specifies any of the known VID/PID pairs.

This now allows my Atmel-ICE debugger to work with openFPGALoader.

AI disclosure: Claude found this and wrote the patch.