### PR TITLE
fix: gowin: use embedded FS checksum for GW5 SRAM finalization

### DIFF
--- a/src/fsparser.cpp
+++ b/src/fsparser.cpp
@@ -15,6 +15,7 @@
 FsParser::FsParser(const std::string &filename, bool reverseByte, bool verbose):
 			ConfigBitstreamParser(filename, ConfigBitstreamParser::ASCII_MODE,
 			verbose), _reverseByte(reverseByte), _end_header(0), _checksum(0),
+			_transfer_checksum(0), _has_transfer_checksum(false),
 			_8Zero(0xff), _4Zero(0xff), _2Zero(0xff),
 			_idcode(0), _compressed(false)
 {
@@ -264,6 +265,19 @@ int FsParser::parse()
 	if (stoul(_hdr["ConfDataLength"]) < nb_line)
 		nb_line = stoi(_hdr["ConfDataLength"]);
 
+	const size_t footer_start = _end_header + 1 + nb_line;
+	for (size_t index = footer_start; index < _lstRawData.size(); ++index) {
+		const string &line = _lstRawData[index];
+		if (line.size() != 64)
+			continue;
+		const uint8_t key = bitToVal(line.c_str(), 8) & 0x7f;
+		if (key == 0x0a) {
+			_transfer_checksum = bitToVal(line.c_str(), line.size()) & 0xffff;
+			_has_transfer_checksum = true;
+			break;
+		}
+	}
+
 	/* drop now useless header */
 	_lstRawData.erase(_lstRawData.begin(), _lstRawData.begin() + _end_header + 1);
 	_lstRawData.resize(nb_line);
@@ -333,7 +347,8 @@ int FsParser::parse()
 		_checksum += (uint16_t)bitToVal(&tmp[pos], 16);
 
 	if (_verbose)
-		printf("checksum 0x%04x\n", _checksum);
+		printf("checksum 0x%04x, transfer checksum 0x%04x\n",
+			_checksum, transferChecksum());
 
 	printSuccess("Done");
 

--- a/src/fsparser.cpp
+++ b/src/fsparser.cpp
@@ -267,7 +267,7 @@ int FsParser::parse()
 
 	const size_t footer_start = _end_header + 1 + nb_line;
 	for (size_t index = footer_start; index < _lstRawData.size(); ++index) {
-		const string &line = _lstRawData[index];
+		const std::string &line = _lstRawData[index];
 		if (line.size() != 64)
 			continue;
 		const uint8_t key = bitToVal(line.c_str(), 8) & 0x7f;

--- a/src/fsparser.hpp
+++ b/src/fsparser.hpp
@@ -20,6 +20,9 @@ class FsParser: public ConfigBitstreamParser {
 		int parse() override;
 
 		uint16_t checksum() {return _checksum;}
+		uint16_t transferChecksum() const {
+			return _has_transfer_checksum ? _transfer_checksum : _checksum;
+		}
 
 	private:
 		int parseHeader();
@@ -36,6 +39,8 @@ class FsParser: public ConfigBitstreamParser {
 		bool _reverseByte; /*!< direct or reverse bit */
 		uint16_t _end_header; /*!< last header line */
 		uint16_t _checksum; /*!< locally computed data checksum */
+		uint16_t _transfer_checksum; /*!< checksum embedded in the bitstream footer */
+		bool _has_transfer_checksum;
 		uint8_t _8Zero; /*!< in compress mode, used to replace 8 * 0x00 */
 		uint8_t _4Zero; /*!< in compress mode, used to replace 8 * 0x00 */
 		uint8_t _2Zero; /*!< in compress mode, used to replace 8 * 0x00 */

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -807,7 +807,8 @@ bool Gowin::writeSRAM(const uint8_t *data, int length)
 	}
 	progress.done();
 	send_command(0x0a);
-	uint32_t checksum = static_cast<FsParser *>(_fs.get())->checksum();
+	FsParser *parser = static_cast<FsParser *>(_fs.get());
+	uint32_t checksum = is_gw5a ? parser->transferChecksum() : parser->checksum();
 	checksum = htole32(checksum);
 	_jtag->shiftDR((uint8_t *)&checksum, NULL, 32);
 	send_command(0x08);


### PR DESCRIPTION
This fixes GOWIN programming on [GW5A](https://gowinsemi.com/en/product/arora-v-fpga/) devices by using the checksum embedded in the FS footer when sending the post-transfer checksum.

openFPGALoader recomputes the checksum from the configuration payload and sends that value after the bitstream transfer. That works for existing devices, but GW5A bitstreams carry a transfer checksum in the footer, and that is the value the device expects during SRAM programming. When the locally computed checksum differs from the footer checksum, configuration can fail.

## This change

- parses the FS footer and captures the checksum entry associated with the transfer command
- exposes that footer-derived value through FsParser, with a fallback to the existing computed checksum when no footer checksum is present
- uses the footer checksum for GW5A SRAM programming while preserving the current behavior for other GOWIN families
- extends verbose logging so both the computed checksum and transfer checksum are visible during debugging

The result is a targeted fix for GW5A devices with no behavior change for older GOWIN parts unless a footer checksum is explicitly present and needed.

## Testing

Verified by the actual downloading of a GW5A-25 revision B silicon. The model no. is GW5A-LV25LQ144C1/I0 with 'B' revision. According to the datasheet, the revision code is shown at the line below the model number line on the chip package.

Disclosure: the patch is written by Copilot, with GPT 5.6 model in the process of fixing the nextpnr workflow for this newer revision of the silicon.