### PR TITLE
xilinxPlatformCableUSB: add more alterneate cables

### DIFF
--- a/doc/cable.yml
+++ b/doc/cable.yml
@@ -351,13 +351,6 @@ xilinxPlatformCableUsb:
     URL: https://www.amd.com/en/products/adaptive-socs-and-fpgas/board-accessories/hw-usb-ii-g.html
 
 
-xilinxPlatformCableUsb_alt:
-
-  - Name: Xilinx Platform Cable USB (XPCU). Alternate VID/PID (found in SP601).
-    Description: Xilinx Platform Cable USB (XPCU) from AMD/Xilinx
-    URL: https://www.amd.com/en/products/adaptive-socs-and-fpgas/board-accessories/hw-usb-ii-g.html
-
-
 xvc-client:
 
   - Name: Xilinx Virtual Cable

--- a/src/cable.hpp
+++ b/src/cable.hpp
@@ -140,8 +140,7 @@ static std::map <std::string, cable_t> cable_list = {
 	{"usb-blasterII",      CABLE_DEF(MODE_USBBLASTER, 0x09Fb, 0x6810                   )},
 	{"usb-blasterII_1",    CABLE_DEF(MODE_USBBLASTER, 0x09Fb, 0x6010                   )},
 	{"usb-blasterIII",     FTDI_SER(0x09fb, 0x6022, FTDI_INTF_A, 0x08, 0x3B, 0x58, 0xb0)},
-	{"xilinxPlatformCableUsb",     CABLE_DEF(MODE_XPCU, 0x03fd, 0x0013                 )},
-	{"xilinxPlatformCableUsb_alt", CABLE_DEF(MODE_XPCU, 0x03fd, 0x000D                 )},
+	{"xilinxPlatformCableUsb", CABLE_DEF(MODE_XPCU, 0x03fd, 0x0008                     )},
 	{"xvc-client",         CABLE_DEF(MODE_XVC_CLIENT, 0x0000, 0x0000                   )},
 #ifdef ENABLE_LIBGPIOD
 	{"libgpiod",           CABLE_DEF(MODE_LIBGPIOD_BITBANG, 0, 0x0000                  )},

--- a/src/fx2_ll.cpp
+++ b/src/fx2_ll.cpp
@@ -31,7 +31,7 @@ FX2_ll::FX2_ll(uint16_t uninit_vid, uint16_t uninit_pid,
 	}
 
 	/* try to open uninitialized device */
-	if (uninit_vid != 0 && uninit_pid != 0) {
+	if (uninit_vid != 0 && uninit_pid != 0 && !firmware_path.empty()) {
 		dev_handle = libusb_open_device_with_vid_pid(usb_ctx,
 				uninit_vid, uninit_pid);
 		if (dev_handle) {
@@ -41,6 +41,7 @@ FX2_ll::FX2_ll(uint16_t uninit_vid, uint16_t uninit_pid,
 				libusb_exit(usb_ctx);
 				throw std::runtime_error("claim interface failed");
 			}
+			printInfo("firmware_file : " + firmware_path);
 			/* load firmware */
 			if (!load_firmware(firmware_path)) {
 				libusb_close(dev_handle);
@@ -53,16 +54,25 @@ FX2_ll::FX2_ll(uint16_t uninit_vid, uint16_t uninit_pid,
 	}
 
 	/* try to open an already init device
-	 * since fx2 may be not immediatly ready
+	 * since fx2 may be not immediately ready
 	 * retry with a delay
 	 */
 	ProgressBar progress("Waiting reload", 100, 50, false);
 	int timeout = 100;
+	int speed = LIBUSB_SPEED_UNKNOWN;
 	do {
 		dev_handle = libusb_open_device_with_vid_pid(usb_ctx,
 				vid, pid);
 		timeout--;
 		progress.display(100-timeout);
+		if (dev_handle) {
+			speed = libusb_get_device_speed(libusb_get_device(dev_handle));
+			if (speed != LIBUSB_SPEED_HIGH) {
+				libusb_close(dev_handle);
+				dev_handle = NULL;
+				reenum = true;
+			}
+		}
 		if (!dev_handle)
 			sleep(1);
 	} while (!dev_handle && timeout > 0 && reenum);

--- a/src/libusb_ll.cpp
+++ b/src/libusb_ll.cpp
@@ -180,6 +180,21 @@ bool libusb_ll::scan()
 				break;
 			}
 			found = true;
+		} else if (desc.idVendor == 0x03fd) {
+			switch (desc.idProduct) {
+			case 0x0007:
+			case 0x0008:
+			case 0x0009:
+			case 0x000d:
+			case 0x000f:
+			case 0x0013:
+			case 0x0015:
+				snprintf(probe_type, 256, "xilinxPlatformCableUsb");
+				found = true;
+				break;
+			default:
+				break;
+			}
 		} else {
 			// FIXME: DFU device can't be detected here
 			for (const auto& b : cable_list) {

--- a/src/xilinxPlatformCableUSB.cpp
+++ b/src/xilinxPlatformCableUSB.cpp
@@ -16,8 +16,7 @@
 #include "xilinxPlatformCableUSB.hpp"
 
 #define XPCU_BREQUEST             0xB0
-#define XPCU_INITIALIZED_VID      0x03fd
-#define XPCU_INITIALIZED_PID      0x0008
+#define XPCU_UNINITIALIZED_VID    0x03fd
 #define XPCU_CMD_DISABLE          0x10
 #define XPCU_CMD_ENABLE           0x18
 #define XPCU_CMD_SET_SPEED        0x28
@@ -52,45 +51,88 @@ XilinxPlatformCableUSB::XilinxPlatformCableUSB(const uint16_t vid,
 		_buffer_bit_size((_buffer_size / 2 * 4) - 1)
 {
 	std::string firmware_file;
-	/* firmare path must be known:
-	 * 1/ provided by user
-	 * 2/ from Vivado install directory
-	 * 3/ from ISE install directory
-	 */
-	if (firmware_path.empty() && strlen(ISE_DIR) == 0 && strlen(VIVADO_DIR) == 0) {
-		printError("missing FX2 firmware");
-		printError("use --probe-firmware with something");
-		printError("like /opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/xusb_xp2.hex for ISE");
-		printError("or   /opt/Xilinx/Vivado/VERSION/data/xicom/xusb_xp2.hex for Vivado");
-		printError("Or use -DISE_DIR=/opt/Xilinx/14.7 / -DVIVADO_DIR=/opt/Xilinx/Vivado/VERSION at build time");
-		throw std::runtime_error("xilinxPlatformCableUSB: missing firmware");
+	int i = 0;
+	uint16_t uninit_pid = 0;
+	libusb_context *usb_ctx;
+	libusb_device** devs;
+	struct libusb_device_descriptor desc;
+	struct libusb_device *dev;
+	if (libusb_init(&usb_ctx) < 0)
+		throw std::runtime_error("libusb init failed");
+	if (libusb_get_device_list(NULL, &devs) >= 0) {
+		while ((dev = devs[i++]) != NULL)  {
+			if (libusb_get_device_descriptor(dev, &desc) < 0)
+				continue;
+			if (desc.idVendor == vid && desc.idProduct == pid) {
+				uninit_pid = 0;
+				break;
+			}
+			if (desc.idVendor == XPCU_UNINITIALIZED_VID) {
+				switch (desc.idProduct) {
+				case 0x07:
+					firmware_file = "xusbdfwu.hex";
+					uninit_pid = desc.idProduct;
+					break;
+				case 0x09:
+					firmware_file = "xusb_xup.hex";
+					uninit_pid = desc.idProduct;
+					break;
+				case 0x0d:
+					firmware_file = "xusb_emb.hex";
+					uninit_pid = desc.idProduct;
+					break;
+				case 0x0f:
+					firmware_file = "xusb_xlp.hex";
+					uninit_pid = desc.idProduct;
+					break;
+				case 0x13:
+					firmware_file = "xusb_xp2.hex";
+					uninit_pid = desc.idProduct;
+					break;
+				case 0x15:
+					firmware_file = "xusb_xse.hex";
+					uninit_pid = desc.idProduct;
+					break;
+				default:
+					break;
+				}
+			}
+		}
+		libusb_free_device_list(devs, 1);
 	}
+	libusb_exit(usb_ctx);
 
 	/* Extract firmware according to possibilities */
 	if (!firmware_path.empty())
 		firmware_file = firmware_path;
-	else if (strlen(VIVADO_DIR) > 0)
-		firmware_file = VIVADO_DIR "/data/xicom/";
-	else if (strlen(ISE_DIR) > 0)
-		firmware_file = ISE_DIR "/ISE_DS/ISE/bin/lin64/";
-
-	if (firmware_path.empty()) {
-		if (pid == 0x0d)
-			firmware_file += "xusb_emb.hex";
-		else
-			firmware_file += "xusb_xp2.hex";
+	else if (!firmware_file.empty() && strlen(VIVADO_DIR) > 0)
+		firmware_file = VIVADO_DIR "/data/xicom/" + firmware_file;
+	else if (!firmware_file.empty() && strlen(ISE_DIR) > 0)
+		firmware_file = ISE_DIR "/ISE_DS/ISE/bin/lin64/" + firmware_file;
+	else if (!firmware_file.empty()) {
+		/* firmware path must be known:
+		 * 1/ provided by user
+		 * 2/ from Vivado install directory
+		 * 3/ from ISE install directory
+		 */
+		printError("missing FX2 firmware");
+		printError("use --probe-firmware with something");
+		printError("like /opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/xusb_xp2.hex for ISE");
+		printError("or   /opt/Xilinx/Vivado/VERSION/data/xicom/xusb_xp2.hex for Vivado");
+		printError("or use -DISE_DIR=/opt/Xilinx/14.7 / -DVIVADO_DIR=/opt/Xilinx/Vivado/VERSION at build time");
+		throw std::runtime_error("xilinxPlatformCableUSB: missing firmware");
 	}
-	printInfo("firmware_file : " + firmware_file);
 
 	try {
-		fx2 = std::make_unique<FX2_ll>(vid, pid, XPCU_INITIALIZED_VID,
-				XPCU_INITIALIZED_PID, firmware_file);
+		fx2 = std::make_unique<FX2_ll>(XPCU_UNINITIALIZED_VID, uninit_pid, vid,
+				pid, firmware_file);
 	} catch (std::exception &e) {
 		printError(e.what());
 		throw std::runtime_error("lowlevel init failed");
 	}
 
-	fx2->set_interface_alt_setting(0, 1);
+	if (!fx2->set_interface_alt_setting(0, 1))
+		fx2->set_interface_alt_setting(0, 0);
 
 	displayCableVersion();
 


### PR DESCRIPTION
1. Add more alterneate Xilinx Platform Cable USB (XPCU)
2. Fix possible 'selecting invalid altsetting 1' error
3. Fix FX2 renumeration error
