### PR TITLE
Add STEP-MXO2_V1.1 board support

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -1149,3 +1149,10 @@
   FPGA: Lattice LCMXO2-4000HC-4MG132CC
   Memory: OK
   Flash: OK
+
+- ID: step-mxo2_v1.1
+  Description: STEP MXO2 V1.1
+  URL: https://wiki.stepfpga.com/xo2-4000hc
+  FPGA: Lattice LCMXO2-4000HC-4MG132CC
+  Memory: OK
+  Flash: OK

--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -1152,7 +1152,7 @@
 
 - ID: step-mxo2_v1.1
   Description: STEP MXO2 V1.1
-  URL: https://wiki.stepfpga.com/xo2-4000hc
-  FPGA: Lattice LCMXO2-4000HC-4MG132CC
+  URL: https://wiki.stepfpga.com/step-mxo2%E7%AC%AC%E4%B8%80%E4%BB%A3
+  FPGA: Lattice LCMXO2-1200HC-4MG132C
   Memory: OK
   Flash: OK

--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -1146,7 +1146,7 @@
 - ID: step-mxo2_v2
   Description: STEP MXO2 V2
   URL: https://wiki.stepfpga.com/xo2-4000hc
-  FPGA: Lattice LCMXO2-4000HC-4MG132CC
+  FPGA: Lattice LCMXO2-4000HC-4MG132C
   Memory: OK
   Flash: OK
 

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -297,7 +297,8 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("mini_itx",        "xc7z100ffg900",        "jtag-smt2-nc", SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("vmm3",            "xc7s50csga324",        "ft2232",       SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("step-max10_v1",   "10m02scm153c8g",       "usb-blaster",  SPI_FLASH, 0, 0, CABLE_DEFAULT),
-	JTAG_BOARD("step-mxo2_v2",    "lcmxo2-4000hc-4mg132cc", "ft232",      SPI_FLASH, 0, 0, CABLE_DEFAULT)
+	JTAG_BOARD("step-mxo2_v2",    "lcmxo2-4000hc-4mg132cc", "ft232",      SPI_FLASH, 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("step-mxo2_v1.1",  "lcmxo2-4000hc-4mg132cc", "ft232",      SPI_FLASH, 0, 0, CABLE_DEFAULT)
 };
 
 #endif

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -298,7 +298,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("vmm3",            "xc7s50csga324",        "ft2232",       SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("step-max10_v1",   "10m02scm153c8g",       "usb-blaster",  SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("step-mxo2_v2",    "lcmxo2-4000hc-4mg132cc", "ft232",      SPI_FLASH, 0, 0, CABLE_DEFAULT),
-	JTAG_BOARD("step-mxo2_v1.1",  "lcmxo2-4000hc-4mg132cc", "ft232",      SPI_FLASH, 0, 0, CABLE_DEFAULT)
+	JTAG_BOARD("step-mxo2_v1.1",  "lcmxo2-1200hc-4mg132cc", "ft232",      SPI_FLASH, 0, 0, CABLE_DEFAULT)
 };
 
 #endif

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -297,8 +297,8 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("mini_itx",        "xc7z100ffg900",        "jtag-smt2-nc", SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("vmm3",            "xc7s50csga324",        "ft2232",       SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("step-max10_v1",   "10m02scm153c8g",       "usb-blaster",  SPI_FLASH, 0, 0, CABLE_DEFAULT),
-	JTAG_BOARD("step-mxo2_v2",    "lcmxo2-4000hc-4mg132c", "ft232",       SPI_FLASH, 0, 0, CABLE_DEFAULT),
-	JTAG_BOARD("step-mxo2_v1.1",  "lcmxo2-1200hc-4mg132c", "ft232",       SPI_FLASH, 0, 0, CABLE_DEFAULT)
+	JTAG_BOARD("step-mxo2_v1.1",  "lcmxo2-1200hc-4mg132c", "ft232",       SPI_FLASH, 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("step-mxo2_v2",    "lcmxo2-4000hc-4mg132c", "ft232",       SPI_FLASH, 0, 0, CABLE_DEFAULT)
 };
 
 #endif

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -297,8 +297,8 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("mini_itx",        "xc7z100ffg900",        "jtag-smt2-nc", SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("vmm3",            "xc7s50csga324",        "ft2232",       SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("step-max10_v1",   "10m02scm153c8g",       "usb-blaster",  SPI_FLASH, 0, 0, CABLE_DEFAULT),
-	JTAG_BOARD("step-mxo2_v2",    "lcmxo2-4000hc-4mg132cc", "ft232",      SPI_FLASH, 0, 0, CABLE_DEFAULT),
-	JTAG_BOARD("step-mxo2_v1.1",  "lcmxo2-1200hc-4mg132cc", "ft232",      SPI_FLASH, 0, 0, CABLE_DEFAULT)
+	JTAG_BOARD("step-mxo2_v2",    "lcmxo2-4000hc-4mg132c", "ft232",       SPI_FLASH, 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("step-mxo2_v1.1",  "lcmxo2-1200hc-4mg132c", "ft232",       SPI_FLASH, 0, 0, CABLE_DEFAULT)
 };
 
 #endif


### PR DESCRIPTION
Change:
1. Add board information in both src and doc folders.  

Wiki page for this board: https://wiki.stepfpga.com/step-mxo2%E7%AC%AC%E4%B8%80%E4%BB%A3  
CHIP: Lattice LCMXO2-1200HC-4MG132C 25MHz  

FT232 Board:  
<img width="480" height="168" alt="1" src="https://github.com/user-attachments/assets/6684bf88-e5ce-4ea6-a079-9bd0844cef5b" />  
Main Board:  
<img width="480" height="196" alt="2" src="https://github.com/user-attachments/assets/5195e329-8bed-4983-a901-d2a1a72ec65c" />  
<img width="640" height="176" alt="3" src="https://github.com/user-attachments/assets/f4a79634-1cdb-4496-8094-3daa597d0e3f" />

Tutorial website: https://steward-fu.github.io/website/mcu.htm#step-fpga-mxo2-v1.1