### PR TITLE
Define `NOMINMAX` and various warning suppressions on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,24 @@ if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 	# "actually everything" - including "This feature requires C++20" warnings even in C++20/23 mode.
 endif()
 
+if (MSVC)
+	# Suppress warnings we don't care about
+	add_compile_options(
+		# By default, Windows headers define `min()` and `max()` as macros,
+		# which makes `std::min()` and `std::max()` syntax errors
+		"/DNOMINMAX"
+		# MS considers the names of some POSIX functions like `isatty()` to be deprecated,
+		# in favor of MS-specific names like `_isatty()`
+		"/wd4996"
+		# size_t -> int conversion
+		"/wd4267"
+		# uint16_t -> uint8_t conversion
+		"/wd4244"
+		# truncation from int to bool
+		"/wd4305"
+	)
+endif()
+
 if(ENABLE_OPTIM AND NOT(CMAKE_BUILD_TYPE STREQUAL "Debug"))
 	if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 		set(CMAKE_CXX_FLAGS "-O3 ${CMAKE_CXX_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,10 @@ if (MSVC)
 		# By default, Windows headers define `min()` and `max()` as macros,
 		# which makes `std::min()` and `std::max()` syntax errors
 		"/DNOMINMAX"
+		# <Windows.h> pulls in a lot of headers by default, and a lot of problematic
+		# macros which can cause conflicts, e.g. `interface` and `byte`; this trims it down
+		# a lot
+		"/DWIN32_LEAN_AND_MEAN"
 		# MS considers the names of some POSIX functions like `isatty()` to be deprecated,
 		# in favor of MS-specific names like `_isatty()`
 		"/wd4996"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,9 +164,18 @@ endif()
 ## specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS_DEBUG "-g -Wall -Wextra ${CMAKE_CXX_FLAGS_DEBUG}")
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+	set(CMAKE_CXX_FLAGS_DEBUG "-g -Wall -Wextra ${CMAKE_CXX_FLAGS_DEBUG}")
+	# TODO: the equivalent for MSVC is /W4
+	#
+	# /Wall includes some almost always unwanted stuff, and `clang`'s MSVC compatibility mode considers it to mean
+	# "actually everything" - including "This feature requires C++20" warnings even in C++20/23 mode.
+endif()
+
 if(ENABLE_OPTIM AND NOT(CMAKE_BUILD_TYPE STREQUAL "Debug"))
-	set(CMAKE_CXX_FLAGS "-O3 ${CMAKE_CXX_FLAGS}")
+	if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+		set(CMAKE_CXX_FLAGS "-O3 ${CMAKE_CXX_FLAGS}")
+	endif()
 endif()
 
 if (BUILD_STATIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,8 @@ if (MSVC)
 		"/wd4244"
 		# truncation from int to bool
 		"/wd4305"
+		# unsafe use of type 'bool' in operation - usually `_verbose > 0` where `_verbose` is bool
+		"/wd4804"
 	)
 endif()
 


### PR DESCRIPTION
Builds on (and includes) #706 

I've kept the `(bool > 0)` thing as a separate commit as I'm unsure if your `(_verbose > 0)` checks are are a bug or if they're future-proofing in case of multiple verbosity levels in the future.