### PR TITLE
Improve win32 portability of display and progressbar

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -23,7 +23,7 @@
 void printError(const std::string &err, bool eol)
 {
 	if (isatty(STDERR_FILENO))
-		std::cerr << KRED << err << "\e[0m";
+		std::cerr << KRED << err << "\033[0m";
 	else
 		std::cerr << err;
 	std::cerr << std::flush;
@@ -34,7 +34,7 @@ void printError(const std::string &err, bool eol)
 void printWarn(const std::string &warn, bool eol)
 {
 	if (isatty(STDOUT_FILENO))
-		std::cout << KYEL << warn << "\e[0m" << std::flush;
+		std::cout << KYEL << warn << "\033[0m" << std::flush;
 	else
 		std::cout << warn;
 	std::cout << std::flush;
@@ -45,7 +45,7 @@ void printWarn(const std::string &warn, bool eol)
 void printInfo(const std::string &info, bool eol)
 {
 	if (isatty(STDOUT_FILENO))
-		std::cout << KBLUL << info << "\e[0m" << std::flush;
+		std::cout << KBLUL << info << "\033[0m" << std::flush;
 	else
 		std::cout << info;
 	std::cout << std::flush;
@@ -56,7 +56,7 @@ void printInfo(const std::string &info, bool eol)
 void printSuccess(const std::string &success, bool eol)
 {
 	if (isatty(STDOUT_FILENO))
-		std::cout << KGRN << success << "\e[0m" << std::flush;
+		std::cout << KGRN << success << "\033[0m" << std::flush;
 	else
 		std::cout << success;
 	std::cout << std::flush;

--- a/src/progressBar.cpp
+++ b/src/progressBar.cpp
@@ -17,7 +17,7 @@ ProgressBar::ProgressBar(const std::string &mess, int maxValue,
 		int progressLen, bool quiet): _mess(mess), _maxValue(maxValue),
 		_progressLen(progressLen), last_time(std::chrono::system_clock::now()),
 		_quiet(quiet), _first(true),
-		_is_tty(_force_terminal_mode || isatty(STDOUT_FILENO) == 1)
+	        _is_tty(_force_terminal_mode || isatty(STDOUT_FILENO))
 {
 }
 


### PR DESCRIPTION
- modern windows terminals support terminal escape codes, however MSVC does not recognize `\e`
- win32 `isatty()` returns 0 or non-zero (in my case, 64) instead of just '0 or 1'. All other callers of isatty in v1.1.1 only check truthiness, not == 1

refs #704