### PR TITLE
Use `std::filesystem` for win32 absolute path conversions

### DIFF
--- a/src/pathHelper.cpp
+++ b/src/pathHelper.cpp
@@ -6,31 +6,12 @@
 #if defined (_WIN64) || defined (_WIN32)
 #include "pathHelper.hpp"
 
-#include <iostream>
-#include <memory>
-#include <string>
-#include <array>
-#include <regex>
+#include <filesystem>
 
 std::string PathHelper::absolutePath(std::string input_path) {
-
-    /* Attempt to execute cygpath */
-    std::string cmd = std::string("cygpath -m " + input_path);
-
-    std::array<char, 128> buffer;
-    std::string result;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
-    if (!pipe) {
-        /* If cygpath fails to run, return original path */
-        return input_path;
-    }
-    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
-        result += buffer.data();
-    }
-
-    /* Trim trailing newline */
-    static const std::regex tws{"[[:space:]]*$", std::regex_constants::extended};
-    return std::regex_replace(result, tws, "");
+    std::error_code ec;
+    const auto absolute = std::filesystem::absolute(input_path, ec);
+    if (ec) return input_path;
+    return absolute.generic_string();
 }
-
 #endif


### PR DESCRIPTION
Avoids dependency on cygpath.

Part of C++17, so *does not* depend on #705 

refs #704