### PR TITLE
Add vcpkg.json dependency information

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
+  "dependencies": [
+    {
+      "name": "pkgconf",
+      "host": true
+    },
+    "libftdi1",
+    "libusb",
+    "zlib"
+  ]
+}


### PR DESCRIPTION
This *can* be used on Linux and macOS, but I'm primarily adding it for native win32.

If I build with `-DCMAKE_TOOLCHAIN_FILE=D:/vcpkg/scripts/buildsystems/vcpkg.cmake`, these dependencies are automatically installed and made available via pkg-config (or in this case, the compatible-enough `pkgconf`) or cmake `find_package()`.

Just adding the file does nothing, the developer needs to explicitly opt in to using it at present, e.g. with `CMAKE_TOOLCHAIN_FILE` above

refs #704