### PR TITLE
MSVC compat: replace `__attribute__((packed))` with `#pragma pack(...)`

### DIFF
--- a/src/dfu.hpp
+++ b/src/dfu.hpp
@@ -51,6 +51,7 @@ class DFU {
 		/**
 		 * \brief dfu descriptor structure (not provided by libusb
 		 */
+#pragma pack(push, 1)
 		struct dfu_desc {
 			uint8_t  bLength;
 			uint8_t  bDescriptorType;
@@ -58,7 +59,8 @@ class DFU {
 			uint16_t wDetachTimeOut;
 			uint16_t wTransferSize;
 			uint16_t bcdDFUVersion;
-		} __attribute__((__packed__));
+		};
+#pragma pack(pop)
 
 		struct dfu_dev {
 			uint16_t vid;

--- a/src/esp_usb_jtag.cpp
+++ b/src/esp_usb_jtag.cpp
@@ -126,10 +126,12 @@ this description is a copy from openocd/src/jtag/drivers/esp_usb_jtag.c
 /* begin copy from openocd */
 
 #define JTAG_PROTO_CAPS_VER 1	/* Version field. At the moment, only version 1 is defined. */
+#pragma pack(push, 1)
 struct jtag_proto_caps_hdr {
 	uint8_t proto_ver;	/* Protocol version. Expects JTAG_PROTO_CAPS_VER for now. */
 	uint8_t length;	/* of this plus any following descriptors */
-} __attribute__((packed));
+};
+#pragma pack(pop)
 
 /* start of the descriptor headers */
 #define JTAG_BUILTIN_DESCR_START_OFF            0	/* Devices with builtin usb jtag */
@@ -149,18 +151,22 @@ Note: If the JTAG device has larger buffers than endpoint-size-plus-a-bit, we sh
 of caps header to assume this. If no such caps exist, assume a minimum (in) buffer of endpoint size + 4.
 */
 
+#pragma pack(push, 1)
 struct jtag_gen_hdr {
 	uint8_t type;
 	uint8_t length;
-} __attribute__((packed));
+};
+#pragma pack(pop)
 
+#pragma pack(push, 1)
 struct jtag_proto_caps_speed_apb {
 	uint8_t type;					/* Type, always JTAG_PROTO_CAPS_SPEED_APB_TYPE */
 	uint8_t length;					/* Length of this */
 	uint8_t apb_speed_10khz[2];		/* ABP bus speed, in 10KHz increments. Base speed is half this. */
 	uint8_t div_min[2];				/* minimum divisor (to base speed), inclusive */
 	uint8_t div_max[2];				/* maximum divisor (to base speed), inclusive */
-} __attribute__((packed));
+};
+#pragma pack(pop)
 
 #define JTAG_PROTO_CAPS_DATA_LEN                255
 #define JTAG_PROTO_CAPS_SPEED_APB_TYPE          1

--- a/src/jlink.hpp
+++ b/src/jlink.hpp
@@ -131,6 +131,7 @@ class Jlink: public JtagInterface {
 		};
 		
 		// Jlink configuration structure
+#pragma pack(push, 1)
 		struct jlink_cfg_t {
 			uint8_t usb_adr;
 			uint8_t reserved1[3];   // 0x01 - 0x03: 0xff
@@ -141,7 +142,8 @@ class Jlink: public JtagInterface {
 			uint8_t reserved3[8];   // 0x08 - 0x1F: 0xff
 			uint8_t mackaddr[6];    // MAC-Address (Only for J-Link Pro)
 			uint8_t reserved[202];  // MAC-Address (Only for J-Link Pro)
-		} __attribute__((__packed__));
+		};
+#pragma pack(pop)
 		typedef jlink_cfg_t jlink_cfg;
 
 		// JLink caps code


### PR DESCRIPTION
Unfortunately there's no standard, but `#pragma pack` is supported by GCC, clang, and MSVC, whereas MSVC doesn't support an attribute for it.

refs #704