### PR TITLE
Replace `ssize_t` with `ptrdiff_t` for pointer offsets

### DIFF
--- a/src/svf_jtag.cpp
+++ b/src/svf_jtag.cpp
@@ -41,8 +41,8 @@ static unsigned char *parse_hex(std::string const &in, size_t byte_length,
 {
 	unsigned char *txbuf = new unsigned char[byte_length];
 	char c;
-	ssize_t last_iter = in.size() - (2 * byte_length);
-	for (ssize_t i = (in.size() - 1), pos = 0; i >= last_iter; i--, pos++) {
+	ptrdiff_t last_iter = in.size() - (2 * byte_length);
+	for (ptrdiff_t i = (in.size() - 1), pos = 0; i >= last_iter; i--, pos++) {
 		if (i < 0) {
 			c = default_value ? 0x0f : 0x00;
 		} else {


### PR DESCRIPTION
`ssize_t` isn't usually available in Win32, though some of the dependencies end up defining it for the other callers.

As it's not available here, use `std::ptrdiff_t` instead.

This change is primarily for Win32 compatability, however it's also semantically more accurate: `ssize_t` is intended for 'size or error'

refs #704