### PR TITLE
MSVC: Add `portability/{ftdi,unistd}.hpp`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,8 @@ set(OPENFPGALOADER_HEADERS
 	src/display.hpp
 	src/part.hpp
 	src/progressBar.hpp
+	src/portability/ftdi.hpp
+	src/portability/unistd.hpp
 )
 
 # ===========================

--- a/src/bpiFlash.cpp
+++ b/src/bpiFlash.cpp
@@ -6,7 +6,7 @@
 
 #include "bpiFlash.hpp"
 
-#include <unistd.h>
+#include "portability/unistd.hpp"
 #include <cstring>
 #include <stdexcept>
 #include <vector>

--- a/src/ch347jtag.cpp
+++ b/src/ch347jtag.cpp
@@ -8,7 +8,7 @@
 #include <libusb.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <cassert>
 #include <iostream>

--- a/src/ch552_jtag.hpp
+++ b/src/ch552_jtag.hpp
@@ -5,7 +5,7 @@
 
 #ifndef SRC_CH552_JTAG_HPP_
 #define SRC_CH552_JTAG_HPP_
-#include <ftdi.h>
+#include "portability/ftdi.hpp"
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/cmsisDAP.cpp
+++ b/src/cmsisDAP.cpp
@@ -15,7 +15,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <iostream>
 #include <map>

--- a/src/colognechip.hpp
+++ b/src/colognechip.hpp
@@ -7,7 +7,7 @@
 #ifndef SRC_COLOGNECHIP_HPP_
 #define SRC_COLOGNECHIP_HPP_
 
-#include <unistd.h>
+#include "portability/unistd.hpp"
 #include <regex>
 #include <string>
 

--- a/src/configBitstreamParser.cpp
+++ b/src/configBitstreamParser.cpp
@@ -8,7 +8,7 @@
 #include <string>
 #include <stdint.h>
 #include <strings.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #ifdef HAS_ZLIB
 #ifdef HAS_ZLIBNG

--- a/src/dfu.cpp
+++ b/src/dfu.cpp
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <iostream>
 #include <map>

--- a/src/dfuFileParser.cpp
+++ b/src/dfuFileParser.cpp
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <iostream>
 #include <fstream>

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2019 Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>
  */
 
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <iostream>
 #include <string>

--- a/src/efinix.cpp
+++ b/src/efinix.cpp
@@ -6,7 +6,7 @@
 #include "efinix.hpp"
 
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <algorithm>
 #include <iostream>

--- a/src/ftdiJtagBitbang.hpp
+++ b/src/ftdiJtagBitbang.hpp
@@ -5,7 +5,7 @@
 
 #ifndef FTDIJTAGBITBANG_H
 #define FTDIJTAGBITBANG_H
-#include <ftdi.h>
+#include "portability/ftdi.hpp"
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/ftdiJtagMPSSE.hpp
+++ b/src/ftdiJtagMPSSE.hpp
@@ -6,7 +6,7 @@
 #ifndef SRC_FTDIJTAGMPSSE_HPP_
 #define SRC_FTDIJTAGMPSSE_HPP_
 
-#include <ftdi.h>
+#include "portability/ftdi.hpp"
 
 #include <cstdint>
 #include <iostream>

--- a/src/ftdipp_mpsse.cpp
+++ b/src/ftdipp_mpsse.cpp
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <iostream>
 #include <stdexcept>

--- a/src/ftdipp_mpsse.hpp
+++ b/src/ftdipp_mpsse.hpp
@@ -5,7 +5,7 @@
 
 #ifndef _FTDIPP_MPSSE_H
 #define _FTDIPP_MPSSE_H
-#include <ftdi.h>
+#include "portability/ftdi.hpp"
 #include <string>
 
 #include "cable.hpp"

--- a/src/ftdispi.cpp
+++ b/src/ftdispi.cpp
@@ -5,8 +5,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <ftdi.h>
-#include <unistd.h>
+#include "portability/ftdi.hpp"
+#include "portability/unistd.hpp"
 #include <string.h>
 
 #include "board.hpp"

--- a/src/ftdispi.hpp
+++ b/src/ftdispi.hpp
@@ -6,7 +6,7 @@
 #ifndef SRC_FTDISPI_HPP_
 #define SRC_FTDISPI_HPP_
 
-#include <ftdi.h>
+#include "portability/ftdi.hpp"
 #include <iostream>
 #include <vector>
 

--- a/src/fx2_ll.cpp
+++ b/src/fx2_ll.cpp
@@ -5,7 +5,7 @@
 
 #include <libusb.h>
 #include <stdint.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <stdexcept>
 #include <string>

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <iostream>
 #include <stdexcept>

--- a/src/ice40.cpp
+++ b/src/ice40.cpp
@@ -6,7 +6,7 @@
 #include "ice40.hpp"
 
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <iostream>
 #include <string>

--- a/src/jetsonNanoJtagBitbang.cpp
+++ b/src/jetsonNanoJtagBitbang.cpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <stdexcept>
 
-#include <unistd.h>
+#include "portability/unistd.hpp"
 #include <sys/fcntl.h>
 #include <sys/mman.h>
 

--- a/src/jlink.cpp
+++ b/src/jlink.cpp
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <map>
 #include <stdexcept>

--- a/src/jtag.cpp
+++ b/src/jtag.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 #include <map>
 #include <sstream>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 #include <vector>
 #include <string>
 

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <strings.h>
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <iomanip>
 #include <iostream>

--- a/src/latticeSSPI.cpp
+++ b/src/latticeSSPI.cpp
@@ -6,7 +6,7 @@
 #include "latticeSSPI.hpp"
 
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #define __STDC_FORMAT_MACROS
 #include <cinttypes>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
  */
 
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <fstream>
 #include <iomanip>

--- a/src/portability/ftdi.hpp
+++ b/src/portability/ftdi.hpp
@@ -1,0 +1,13 @@
+#ifndef _SRC_PORTABILITY_FTDI_HPP_
+#define _SRC_PORTABILITY_FTDI_HPP_
+// libftdi uses `timeval`; it attempts to access this by pulling in
+// <sys/time.h> on win32. This is incorrect, but generally works - however,
+// with `WIN32_LEAN_AND_MEAN` (which prevents unrelated win32 root namespace
+// pollution, e.g. a `byte` type), the correct include is needed
+#if __has_include(<WinSock2.h>)
+#include <WinSock2.h>
+#endif
+
+#include <ftdi.h>
+
+#endif

--- a/src/portability/unistd.hpp
+++ b/src/portability/unistd.hpp
@@ -1,0 +1,40 @@
+#ifndef _SRC_PORTABILITY_UNISTD_HPP
+#define _SRC_PORTABILITY_UNISTD_HPP
+
+#if __has_include(<unistd.h>)
+#include "portability/unistd.hpp"
+#elif defined(_MSC_VER)
+
+#include <chrono>
+#include <thread>
+
+#include <io.h>
+
+#ifndef STDIN_FILENO
+#define STDIN_FILENO 0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+#endif
+
+using useconds_t = unsigned long long;
+
+static int usleep(const useconds_t usec) {
+  if (usec < 0) {
+    _set_errno(EINVAL);
+    return -1;
+  }
+  if (usec == 0) {
+    return 0;
+  }
+  std::this_thread::sleep_for(std::chrono::microseconds(usec));
+  return 0;
+}
+
+static int sleep(const unsigned int seconds) {
+  std::this_thread::sleep_for(std::chrono::seconds(seconds));
+  return 0;
+}
+
+#endif
+
+#endif

--- a/src/progressBar.cpp
+++ b/src/progressBar.cpp
@@ -5,7 +5,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 #include <chrono>
 #include <string>
 #include "progressBar.hpp"

--- a/src/remoteBitbang_client.cpp
+++ b/src/remoteBitbang_client.cpp
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 #include <math.h>
 
 #include <map>

--- a/src/spiFlash.cpp
+++ b/src/spiFlash.cpp
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 #include <cmath>
 #include <map>
 #include <iostream>

--- a/src/svf_jtag.cpp
+++ b/src/svf_jtag.cpp
@@ -8,7 +8,7 @@
 #include "svf_jtag.hpp"
 
 #include <stdexcept>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <algorithm>
 #include <iostream>

--- a/src/usbBlaster.hpp
+++ b/src/usbBlaster.hpp
@@ -6,7 +6,7 @@
 #ifndef SRC_USBBLASTER_HPP_
 #define SRC_USBBLASTER_HPP_
 #ifdef USE_LIBFTDI
-#include <ftdi.h>
+#include "portability/ftdi.hpp"
 #endif
 #include <iostream>
 #include <string>

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -6,7 +6,7 @@
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <cstring>
 #include <fstream>

--- a/src/xvc_client.cpp
+++ b/src/xvc_client.cpp
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <string.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 #include <math.h>
 
 #include <map>

--- a/src/xvc_server.cpp
+++ b/src/xvc_server.cpp
@@ -9,7 +9,7 @@
 #include <sys/socket.h>
 #include <errno.h>
 #include <netinet/tcp.h>
-#include <unistd.h>
+#include "portability/unistd.hpp"
 
 #include <cstring>
 #include <stdexcept>


### PR DESCRIPTION
- FTDI: add missing `<WinSock2.h>` include on Windows, needed for timespan
- unistd: polyfill used definitions if header is unavailable

refs #704