### PR TITLE
Fix exception that is created but not thrown

### DIFF
--- a/src/altera.cpp
+++ b/src/altera.cpp
@@ -384,9 +384,9 @@ bool Altera::max10_program_ufm(const Altera::max10_mem_t *mem, uint32_t offset,
 	uint32_t end_addr = 0; // 32bit align
 	uint8_t erase_sectors_mask;
 
-	/* check CFM0 is not mentionned */
+	/* check CFM0 is not mentioned */
 	if (update_sectors & (1 << 4))
-		std::runtime_error("Error: CFM0 cant't be used to store User Binary");
+		throw std::runtime_error("Error: CFM0 can't be used to store User Binary");
 
 	/* First task: search for the first and the last sector to use */
 	sectors_mask_start_end_addr(mem, update_sectors,


### PR DESCRIPTION
Detected by MSVC warning for `[[nodiscard]]` attribute, but not needed for MSVC compat.

Also fix typos while I'm here.