### PR TITLE
MSVC: Replace C99 dynamic-sized arrays with std::vector

### DIFF
--- a/src/altera.cpp
+++ b/src/altera.cpp
@@ -1303,8 +1303,9 @@ int Altera::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 	 * one bit
 	 */
 	int xfer_len = len + 1 + ((rx == NULL) ? 0 : 1);
-	uint8_t jtx[xfer_len];
-	uint8_t jrx[xfer_len];
+	std::vector<uint8_t> jtx, jrx;
+	jtx.resize(xfer_len);
+	jrx.resize(xfer_len);
 
 	if (tx != NULL) {
 		for (uint32_t i = 0; i < len; i++)
@@ -1312,7 +1313,7 @@ int Altera::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 	}
 
 	shiftVIR(RawParser::reverseByte(cmd));
-	shiftVDR(jtx, (rx) ? jrx : NULL, 8 * xfer_len);
+	shiftVDR(jtx.data(), (rx) ? jrx.data() : NULL, 8 * xfer_len);
 
 	if (rx) {
 		for (uint32_t i = 0; i < len; i++) {

--- a/src/anlogic.cpp
+++ b/src/anlogic.cpp
@@ -197,8 +197,9 @@ int Anlogic::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 	int xfer_len = len + 1;
 	if (rx)
 		xfer_len++;
-	uint8_t jtx[xfer_len];
-	uint8_t jrx[xfer_len];
+	std::vector<uint8_t> jtx, jrx;
+	jtx.resize(xfer_len);
+	jrx.resize(xfer_len);
 
 	jtx[0] = AnlogicBitParser::reverseByte(cmd);
 	if (tx != NULL) {
@@ -210,7 +211,7 @@ int Anlogic::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 	uint8_t op = 0x60;
 	_jtag->shiftDR(&op, NULL, 8);
 
-	_jtag->shiftDR(jtx, (rx == NULL)? NULL: jrx, 8*xfer_len);
+	_jtag->shiftDR(jtx.data(), (rx == NULL)? NULL: jrx.data(), 8*xfer_len);
 	if (rx != NULL) {
 		for (uint32_t i=0; i < len; i++)
 			rx[i] = AnlogicBitParser::reverseByte(jrx[i+1]>>1)
@@ -223,8 +224,9 @@ int Anlogic::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 	int xfer_len = len;
 	if (rx)
 		xfer_len++;
-	uint8_t jtx[xfer_len];
-	uint8_t jrx[xfer_len];
+	std::vector<uint8_t> jtx, jrx;
+	jtx.resize(xfer_len);
+	jrx.resize(xfer_len);
 
 	if (tx != NULL) {
 		for (uint32_t i = 0; i < len; i++)
@@ -235,7 +237,7 @@ int Anlogic::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 	uint8_t op = 0x60;
 	_jtag->shiftDR(&op, NULL, 8);
 
-	_jtag->shiftDR(jtx, (rx == NULL)? NULL: jrx, 8*xfer_len);
+	_jtag->shiftDR(jtx.data(), (rx == NULL)? NULL: jrx.data(), 8*xfer_len);
 	if (rx != NULL) {
 		for (uint32_t i=0; i < len; i++)
 			rx[i] = AnlogicBitParser::reverseByte(jrx[i]>>1) |

--- a/src/ch552_jtag.cpp
+++ b/src/ch552_jtag.cpp
@@ -120,9 +120,10 @@ int CH552_jtag::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer,
 
 		mpsse_store(buf, 3);
 		if (pos >= iter) {
-			uint8_t tmp[_to_read];
+			std::vector<uint8_t> tmp;
+			tmp.resize(_to_read);
 			pos = 0;
-			if (-1 == mpsse_read(tmp, _to_read))
+			if (-1 == mpsse_read(tmp.data(), _to_read))
 				printError("writeTMS: Fail to read/write");
 			_to_read = 0;
 		}
@@ -131,8 +132,9 @@ int CH552_jtag::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer,
 
 	if (flush_buffer) {
 		if (_to_read > 0) {
-			uint8_t tmp[_to_read];
-			if (mpsse_read(tmp, _to_read) == -1)
+			std::vector<uint8_t> tmp;
+			tmp.resize(_to_read);
+			if (mpsse_read(tmp.data(), _to_read) == -1)
 				printError("writeTMS: fail to flush");
 			_to_read = 0;
 		}
@@ -149,10 +151,11 @@ int CH552_jtag::toggleClk(uint8_t tms, uint8_t tdi, uint32_t clk_len)
 	(void) tdi;
 
 	int byteLen = (clk_len+7)/8;
-	uint8_t buf_tms[byteLen];
+	std::vector<uint8_t> buf_tms;
+	buf_tms.resize(byteLen);
 
-	memset(buf_tms, (tms) ? 0xff : 0x00, byteLen);
-	return writeTMS(buf_tms, clk_len, false);
+	memset(buf_tms.data(), (tms) ? 0xff : 0x00, byteLen);
+	return writeTMS(buf_tms.data(), clk_len, false);
 }
 
 int CH552_jtag::flush()
@@ -163,8 +166,9 @@ int CH552_jtag::flush()
 		if (ret == -1)
 			printError("flush: fails to write");
 	} else {
-		uint8_t tmp[_to_read];
-		ret = mpsse_read(tmp, _to_read);
+		std::vector<uint8_t> tmp;
+		tmp.resize(_to_read);
+		ret = mpsse_read(tmp.data(), _to_read);
 		if (ret == -1)
 			printError("flush: fails to read/write");
 		_to_read = 0;
@@ -199,8 +203,9 @@ int CH552_jtag::writeTDI(const uint8_t *tdi, uint8_t *tdo, uint32_t len, bool la
 	uint8_t oneshot_buf[3] = {rd_cmd, 0, 0};
 
 	if (_to_read != 0) {
-		uint8_t tmp_[_to_read];
-		if (mpsse_read(tmp_, _to_read) == -1)
+		std::vector<uint8_t> tmp_;
+		tmp_.resize(_to_read);
+		if (mpsse_read(tmp_.data(), _to_read) == -1)
 			printError("writeTDI: fails to flush read");
 		_to_read = 0;
 	}

--- a/src/colognechip.cpp
+++ b/src/colognechip.cpp
@@ -415,8 +415,9 @@ void CologneChip::programJTAG_flash(unsigned int offset, const uint8_t *data,
 int CologneChip::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int xfer_len = len + 1;
-	uint8_t jtx[xfer_len+2];
-	uint8_t jrx[xfer_len+2];
+	std::vector<uint8_t> jtx, jrx;
+	jtx.resize(xfer_len+2, 0);
+	jrx.resize(xfer_len+2, 0);
 
 	jtx[0] = ConfigBitstreamParser::reverseByte(cmd);
 
@@ -428,7 +429,7 @@ int CologneChip::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t l
 	_jtag->shiftIR(JTAG_SPI_BYPASS, 6, Jtag::SHIFT_DR);
 
 	int drlen = (rx == NULL) ? 8*xfer_len : 8*xfer_len+1;
-	_jtag->read_write(jtx, (rx == NULL) ? NULL : jrx, drlen, false);
+	_jtag->read_write(jtx.data(), (rx == NULL) ? NULL : jrx.data(), drlen, false);
 
 	int shift = _jtag->get_devices_list().size();
 
@@ -448,8 +449,9 @@ int CologneChip::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t l
 int CologneChip::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int xfer_len = len;
-	uint8_t jtx[xfer_len+2];
-	uint8_t jrx[xfer_len+2];
+	std::vector<uint8_t> jtx, jrx;
+	jtx.resize(xfer_len+2, 0);
+	jrx.resize(xfer_len+2, 0);
 
 	if (tx != NULL) {
 		for (uint32_t i=0; i < len; i++)
@@ -457,7 +459,7 @@ int CologneChip::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 	}
 
 	_jtag->shiftIR(JTAG_SPI_BYPASS, 6, Jtag::SELECT_DR_SCAN);
-	_jtag->shiftDR(jtx, (rx == NULL)? NULL: jrx, 8*xfer_len+1, Jtag::SELECT_DR_SCAN);
+	_jtag->shiftDR(jtx.data(), (rx == NULL)? NULL: jrx.data(), 8*xfer_len+1, Jtag::SELECT_DR_SCAN);
 
 	if (rx != NULL) {
 		for (uint32_t i=0; i < len; i++) {

--- a/src/dirtyJtag.cpp
+++ b/src/dirtyJtag.cpp
@@ -256,15 +256,16 @@ int DirtyJtag::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 	uint32_t real_bit_len = len - (end ? 1 : 0);
 	const uint32_t kRealByteLen = (len + 7) / 8;
 
-	uint8_t tx_cpy[kRealByteLen];
+	std::vector<uint8_t> tx_cpy;
+	tx_cpy.resize(kRealByteLen);
 	uint8_t tx_buf[512], rx_buf[512];
 	uint8_t *tx_ptr, *rx_ptr = rx;
 
+	tx_ptr = tx_cpy.data();
 	if (tx)
-		memcpy(tx_cpy, tx, kRealByteLen);
+		memcpy(tx_ptr, tx, kRealByteLen);
 	else
-		memset(tx_cpy, 0, kRealByteLen);
-	tx_ptr = tx_cpy;
+		memset(tx_ptr, 0, kRealByteLen);
 
 	tx_buf[0] = CMD_XFER | (rx ? 0 : v_options[_version].no_read);
 	uint16_t max_bit_transfer_length = v_options[_version].max_bits;

--- a/src/efinix.cpp
+++ b/src/efinix.cpp
@@ -483,9 +483,10 @@ int Efinix::spi_put(uint8_t cmd,
 			const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int kXferLen = len + 1 + ((rx == NULL) ? 0 : 1);
-	uint8_t jtx[kXferLen];
+	std::vector<uint8_t> jtx, jrx;
+	jtx.resize(kXferLen, 0);
+	jrx.resize(kXferLen, 0);
 	jtx[0] = EfinixHexParser::reverseByte(cmd);
-	uint8_t jrx[kXferLen];
 	if (tx != NULL) {
 		for (uint32_t i=0; i < len; i++)
 			jtx[i+1] = EfinixHexParser::reverseByte(tx[i]);
@@ -496,7 +497,7 @@ int Efinix::spi_put(uint8_t cmd,
 	 * in the same time store each byte
 	 * to next
 	 */
-	_jtag->shiftDR(jtx, (rx == NULL)? NULL: jrx, 8*kXferLen);
+	_jtag->shiftDR(jtx.data(), (rx == NULL)? NULL: jrx.data(), 8*kXferLen);
 
 	if (rx != NULL) {
 		for (uint32_t i=0; i < len; i++)
@@ -508,8 +509,9 @@ int Efinix::spi_put(uint8_t cmd,
 int Efinix::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int kXferLen = len + ((rx == NULL) ? 0 : 1);
-	uint8_t jtx[kXferLen];
-	uint8_t jrx[kXferLen];
+	std::vector<uint8_t> jtx, jrx;
+	jtx.resize(kXferLen, 0);
+	jrx.resize(kXferLen, 0);
 	if (tx != NULL) {
 		for (uint32_t i=0; i < len; i++)
 			jtx[i] = EfinixHexParser::reverseByte(tx[i]);
@@ -520,7 +522,7 @@ int Efinix::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 	 * in the same time store each byte
 	 * to next
 	 */
-	_jtag->shiftDR(jtx, (rx == NULL)? NULL: jrx, 8*kXferLen);
+	_jtag->shiftDR(jtx.data(), (rx == NULL)? NULL: jrx.data(), 8*kXferLen);
 
 	if (rx != NULL) {
 		for (uint32_t i=0; i < len; i++)

--- a/src/esp_usb_jtag.cpp
+++ b/src/esp_usb_jtag.cpp
@@ -669,7 +669,8 @@ int esp_usb_jtag::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool en
 	}
 	int ret;
 	const uint32_t kTdiLen = (len+7) >> 3; // TDI/RX len in byte
-	uint8_t tdi[kTdiLen]; // TDI buffer (required when tx is NULL)
+	std::vector<uint8_t> tdi; // TDI buffer (required when tx is NULL)
+	tdi.resize(kTdiLen);
 	uint8_t tx_buf[OUT_EP_SZ];
 	const uint8_t tdo = !(rx == NULL); // only set cap/tdo when something to read
 	uint8_t *rx_ptr = NULL;
@@ -687,9 +688,9 @@ int esp_usb_jtag::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool en
 
 	/* Copy RX or fill the buffer with TDI current level */
 	if (tx)
-		memcpy(tdi, tx, kTdiLen);
+		memcpy(tdi.data(), tx, kTdiLen);
 	else
-		memset(tdi, _tdi ? 0xff : 0x00, kTdiLen);
+		memset(tdi.data(), _tdi ? 0xff : 0x00, kTdiLen);
 
 	if (_verbose) {
 		snprintf(mess, 256, "len=0x%08x\n", len);

--- a/src/ftdiJtagMPSSE.cpp
+++ b/src/ftdiJtagMPSSE.cpp
@@ -155,8 +155,9 @@ int FtdiJtagMPSSE::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer,
 				printf("writeTMS: error\n");
 
 			if (_ch552WA) {
-				uint8_t c[len/8+1];
-				int ret = ftdi_read_data(_ftdi, c, len/8+1);
+				std::vector<uint8_t> c;
+				c.resize(len/8+1);
+				int ret = ftdi_read_data(_ftdi, c.data(), len/8+1);
 				if (ret != 0) {
 					printf("ret : %d\n", ret);
 				}
@@ -167,8 +168,9 @@ int FtdiJtagMPSSE::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer,
 	if (flush_buffer)
 		mpsse_write();
 	if (_ch552WA) {
-		uint8_t c[len/8+1];
-		ftdi_read_data(_ftdi, c, len/8+1);
+		std::vector<uint8_t> c;
+		c.resize(len/8+1);
+		ftdi_read_data(_ftdi, c.data(), len/8+1);
 	}
 
 	return len;
@@ -210,9 +212,10 @@ int FtdiJtagMPSSE::toggleClk(uint8_t tms, uint8_t tdi, uint32_t clk_len)
 		ret = clk_len;
 	} else {
 		int byteLen = (len+7)/8;
-		uint8_t buf_tms[byteLen];
-		memset(buf_tms, (tms) ? 0xff : 0x00, byteLen);
-		ret = writeTMS(buf_tms, len, false);
+		std::vector<uint8_t> buf_tms;
+		buf_tms.resize(byteLen);
+		memset(buf_tms.data(), (tms) ? 0xff : 0x00, byteLen);
+		ret = writeTMS(buf_tms.data(), len, false);
 	}
 
 	return ret;
@@ -243,8 +246,9 @@ int FtdiJtagMPSSE::writeTDI(const uint8_t *tdi, uint8_t *tdo, uint32_t len, bool
 	int nb_byte = real_len >> 3;     // number of byte to send
 	int nb_bit = (real_len & 0x07);  // residual bits
 	int xfer = tx_buff_size - 3;
-	unsigned char c[xfer];
-	unsigned char rev[xfer];
+	std::vector<unsigned char> c, rev;
+	c.resize(xfer);
+	rev.resize(xfer);
 	unsigned char *rx_ptr = (unsigned char *)tdo;
 	unsigned char *tx_ptr = (unsigned char *)tdi;
 	bool use_msb_first = _msb_first && !tdo;
@@ -284,7 +288,7 @@ int FtdiJtagMPSSE::writeTDI(const uint8_t *tdi, uint8_t *tdo, uint32_t len, bool
 					rev[i] = bit_reverse(tx_ptr[i]); 
 				}
 			}
-			mpsse_store(use_msb_first ? rev : tx_ptr, xfer_len);
+			mpsse_store(use_msb_first ? rev.data() : tx_ptr, xfer_len);
 			tx_ptr += xfer_len;
 		}
 		if (tdo) {
@@ -292,7 +296,7 @@ int FtdiJtagMPSSE::writeTDI(const uint8_t *tdi, uint8_t *tdo, uint32_t len, bool
 			rx_ptr += xfer_len;
 		} else if (_ch552WA) {
 			mpsse_write();
-			ftdi_read_data(_ftdi, c, xfer_len);
+			ftdi_read_data(_ftdi, c.data(), xfer_len);
 		} else if (!last) {
 			mpsse_write();
 		}
@@ -329,7 +333,7 @@ int FtdiJtagMPSSE::writeTDI(const uint8_t *tdi, uint8_t *tdo, uint32_t len, bool
 				*rx_ptr >>= (8 - nb_bit);
 			} else {
 				mpsse_write();
-				ftdi_read_data(_ftdi, c, nb_bit);
+				ftdi_read_data(_ftdi, c.data(), nb_bit);
 			}
 		} else if (!last) {
 			mpsse_write();
@@ -367,7 +371,7 @@ int FtdiJtagMPSSE::writeTDI(const uint8_t *tdi, uint8_t *tdo, uint32_t len, bool
 			*rx_ptr |= (((c[index]) & 0x80) >> (7 - nb_bit));
 		} else if (_ch552WA) {
 			mpsse_write();
-			ftdi_read_data(_ftdi, c, 1);
+			ftdi_read_data(_ftdi, c.data(), 1);
 		} else {
 			mpsse_write();
 		}
@@ -444,12 +448,14 @@ bool FtdiJtagMPSSE::writeTMSTDI(const uint8_t *tms, const uint8_t *tdi,
 	int32_t ret;
 	uint32_t max_len = 1024;
 	uint8_t mode = 0;          // current state: 0 none, 1 TDI, 2 TMS
-	uint8_t tdi_buf[max_len];  // buffer to store TDI sequence
 	uint8_t tms_tmp = 0;       // buffer to store TMS sequence (limited to 6bits per cmd)
-	uint8_t tdo_tmp[max_len];  // local TDO sequence
+	std::vector<uint8_t> tdi_buf; // buffer to store TDI sequence
+	std::vector<uint8_t> tdo_tmp; // local TDO sequence
+	tdi_buf.resize(max_len);
+	tdo_tmp.resize(max_len);
 	uint32_t buff_len = 0;     // current bits stored
-	memset(tdi_buf, 0, max_len);
-	memset(tdo_tmp, 0, max_len);
+	memset(tdi_buf.data(), 0, max_len);
+	memset(tdo_tmp.data(), 0, max_len);
 	_tdo_pos = 0;  // current bits read
 
 	if (_verbose)
@@ -525,9 +531,9 @@ bool FtdiJtagMPSSE::writeTMSTDI(const uint8_t *tms, const uint8_t *tdi,
 					buff_len++;
 					is_end = true;
 				}
-				writeTDI(tdi_buf, tdo_tmp, buff_len, is_end);
-				update_tdo_buff(tdo_tmp, tdo, buff_len);
-				memset(tdi_buf, 0, max_len);
+				writeTDI(tdi_buf.data(), tdo_tmp.data(), buff_len, is_end);
+				update_tdo_buff(tdo_tmp.data(), tdo, buff_len);
+				memset(tdi_buf.data(), 0, max_len);
 				buff_len = 0;
 				if (is_end) {
 					_curr_tdi = tdi_bit;
@@ -554,9 +560,9 @@ bool FtdiJtagMPSSE::writeTMSTDI(const uint8_t *tms, const uint8_t *tdi,
 
 		/* buffer full? */
 		if (buff_len == 8*max_len && mode == 1) {
-			writeTDI(tdi_buf, tdo_tmp, buff_len, false);
-			update_tdo_buff(tdo_tmp, tdo, buff_len);
-			memset(tdi_buf, 0, max_len);
+			writeTDI(tdi_buf.data(), tdo_tmp.data(), buff_len, false);
+			update_tdo_buff(tdo_tmp.data(), tdo, buff_len);
+			memset(tdi_buf.data(), 0, max_len);
 			buff_len = 0;
 		} else if (buff_len == 6 && mode == 2) {
 			ret = update_tms_buff(&tms_tmp, 0, buff_len, _curr_tdi, tdo, true);
@@ -574,8 +580,8 @@ bool FtdiJtagMPSSE::writeTMSTDI(const uint8_t *tms, const uint8_t *tdi,
 	if (buff_len > 0) {
 		switch (mode) {
 		case 1:
-			writeTDI(tdi_buf, tdo_tmp, buff_len, false);
-			update_tdo_buff(tdo_tmp, tdo, buff_len);
+			writeTDI(tdi_buf.data(), tdo_tmp.data(), buff_len, false);
+			update_tdo_buff(tdo_tmp.data(), tdo, buff_len);
 			break;
 		case 2:
 			if (update_tms_buff(&tms_tmp, 0, buff_len, _curr_tdi,

--- a/src/ftdispi.cpp
+++ b/src/ftdispi.cpp
@@ -172,7 +172,8 @@ int FtdiSpi::ft2232_spi_wr_and_rd(//struct ftdi_spi *spi,
 {
 	// -3: for MPSSE instruction
 	const uint16_t max_xfer = ((readarr) ? _buffer_size : 4096);
-	uint8_t buf[max_xfer];
+	std::vector<uint8_t> buf;
+	buf.resize(max_xfer);
 	uint8_t cmd[] = {
 		static_cast<uint8_t>(((readarr) ? (MPSSE_DO_READ | _rd_mode) : 0) |
 			((writearr) ? (MPSSE_DO_WRITE | _wr_mode) : 0)),
@@ -202,11 +203,11 @@ int FtdiSpi::ft2232_spi_wr_and_rd(//struct ftdi_spi *spi,
 
 		mpsse_store(cmd, 3);
 		if (writearr) {
-			memcpy(buf, tx_ptr, xfer);
+			memcpy(buf.data(), tx_ptr, xfer);
 			tx_ptr += xfer;
 			xfer_len = xfer;
 		}
-		ret = mpsse_store(buf, xfer_len);
+		ret = mpsse_store(buf.data(), xfer_len);
 		if (ret) {
 			printError("send_buf failed before read with error: " +
 				std::string(ftdi_get_error_string(_ftdi)) + " (" +
@@ -247,21 +248,22 @@ int FtdiSpi::ft2232_spi_wr_and_rd(//struct ftdi_spi *spi,
 int FtdiSpi::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	uint32_t xfer_len = len + 1;
-	uint8_t jtx[xfer_len];
-	uint8_t jrx[xfer_len];
+	std::vector<uint8_t> jtx, jrx;
+	jtx.resize(xfer_len);
+	jrx.resize(xfer_len);
 
 	jtx[0] = cmd;
 	if (tx != NULL)
-		memcpy(jtx+1, tx, len);
+		memcpy(&jtx[1], tx, len);
 
 	/* send first already stored cmd,
 	 * in the same time store each byte
 	 * to next
 	 */
-	ft2232_spi_wr_and_rd(xfer_len, jtx, (rx != NULL)?jrx:NULL);
+	ft2232_spi_wr_and_rd(xfer_len, jtx.data(), (rx != NULL)?jrx.data():NULL);
 
 	if (rx != NULL)
-		memcpy(rx, jrx+1, len);
+		memcpy(rx, &jrx[1], len);
 
 	return 0;
 }

--- a/src/gowin.cpp
+++ b/src/gowin.cpp
@@ -1004,35 +1004,39 @@ int Gowin::spi_put(uint8_t cmd, const uint8_t *tx, uint8_t *rx, uint32_t len)
 	if (is_gw5a)
 		return spi_put_gw5a(cmd, tx, rx, len);
 
-	uint8_t jrx[len+1], jtx[len+1];
+	std::vector<uint8_t> jrx, jtx;
+	jrx.resize(len+1);
+	jtx.resize(len+1);
 	jtx[0] = cmd;
 	if (tx)
-		memcpy(jtx+1, tx, len);
+		memcpy(&jtx[1], tx, len);
 	else
-		memset(jtx+1, 0, len);
-	int ret = spi_put(jtx, (rx)? jrx : NULL, len+1);
+		memset(&jtx[1], 0, len);
+	int ret = spi_put(jtx.data(), (rx)? jrx.data() : NULL, len+1);
 	if (rx)
-		memcpy(rx, jrx + 1, len);
+		memcpy(rx, &jrx[1], len);
 	return ret;
 }
 
 int Gowin::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	if (is_gw5a) {
-		uint8_t jrx[len];
+		std::vector<uint8_t> jrx;
+		jrx.resize(len);
 		int ret = spi_put_gw5a(tx[0], (len > 1) ? &tx[1] : NULL,
-				(rx) ? jrx : NULL, len - 1);
+				(rx) ? jrx.data() : NULL, len - 1);
 		// FIXME: first byte is never read (but in most call it's not an issue
 		if (rx) {
 			rx[0] = 0;
-			memcpy(&rx[1], jrx, len - 1);
+			memcpy(&rx[1], jrx.data(), len - 1);
 		}
 		return ret;
 	}
 
 	if (is_gw2a) {
-		uint8_t jtx[len];
-		uint8_t jrx[len];
+		std::vector<uint8_t> jrx, jtx;
+		jrx.resize(len);
+		jtx.resize(len);
 		if (rx)
 			len++;
 		if (tx != NULL) {
@@ -1043,7 +1047,7 @@ int Gowin::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 		if (!ret)
 			return -1;
 		_jtag->set_state(Jtag::EXIT2_DR);
-		_jtag->shiftDR(jtx, (rx)? jrx:NULL, 8*len);
+		_jtag->shiftDR(jtx.data(), (rx)? jrx.data():NULL, 8*len);
 		if (rx) {
 			for (uint32_t i=0; i < len; i++) {
 				rx[i] = FsParser::reverseByte(jrx[i]>>1) |
@@ -1283,16 +1287,18 @@ int Gowin::spi_put_gw5a(const uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 {
 		uint32_t kLen = len + (rx ? 1 : 0);  // cppcheck/lint happy
 		uint32_t bit_len = len * 8 + (rx ? 3 : 0);  // 3bits delay when read
-		uint8_t jtx[kLen], jrx[kLen];
 		uint8_t _cmd = FsParser::reverseByte(cmd);  // reverse cmd.
 		uint8_t curr_tdi = cmd & 0x01;
+		std::vector<uint8_t> jtx, jrx;
+		jtx.resize(kLen);
+		jrx.resize(kLen);
 
 		if (tx != NULL) {  // SPI: MSB, JTAG: LSB -> reverse Bytes
 			for (uint32_t i = 0; i < len; i++)
 				jtx[i] = FsParser::reverseByte(tx[i]);
 			curr_tdi = tx[len-1] & 0x01;
 		} else {
-			memset(jtx, curr_tdi, kLen);
+			memset(jtx.data(), curr_tdi, kLen);
 		}
 
 		// set TMS/CS low by moving to a state where TMS == 0,
@@ -1306,7 +1312,7 @@ int Gowin::spi_put_gw5a(const uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 
 		// write/read the sequence. Force set to 0 to manage state here
 		// (with jtag last bit is sent with tms rise)
-		if (0 != _jtag->read_write(jtx, (rx) ? jrx : NULL, bit_len, 0))
+		if (0 != _jtag->read_write(jtx.data(), (rx) ? jrx.data() : NULL, bit_len, 0))
 			return -1;
 		// set TMS/CS high by moving to a state where TMS == 1
 		_jtag->set_state(Jtag::TEST_LOGIC_RESET, curr_tdi);

--- a/src/latticeSSPI.cpp
+++ b/src/latticeSSPI.cpp
@@ -97,11 +97,11 @@ bool LatticeSSPI::cmd_class_a(uint8_t cmd, uint8_t *rx, uint32_t len)
 {
 	const uint32_t xferByteLen = (len + 7) / 8;
 	const uint32_t kBytetLen = xferByteLen + 3;  // Convert bits to bytes after adding dummy
-	uint8_t lrx[kBytetLen];
-	uint8_t ltx[kBytetLen];
-	memset(ltx, 0x00, kBytetLen);
+	std::vector<uint8_t> lrx, ltx;
+	lrx.resize(kBytetLen, 0);
+	ltx.resize(kBytetLen, 0);
 
-	_spi->spi_put(cmd, ltx, lrx, kBytetLen);
+	_spi->spi_put(cmd, ltx.data(), lrx.data(), kBytetLen);
 
 	memcpy(rx, &lrx[3], xferByteLen);
 

--- a/src/spiFlash.cpp
+++ b/src/spiFlash.cpp
@@ -273,7 +273,8 @@ int SPIFlash::write_page(int addr, const uint8_t *data, int len)
 		write_cmd = FLASH_4PP;
 	}
 
-	uint8_t tx[len+addr_len];
+	std::vector<uint8_t> tx;
+	tx.resize(len+addr_len);
 
 	if (write_cmd == FLASH_4PP)
 		tx[i++] = (uint8_t)(0xff & (addr >> 24));
@@ -281,12 +282,12 @@ int SPIFlash::write_page(int addr, const uint8_t *data, int len)
 	tx[i++] = (uint8_t)(0xff & (addr >>  8));
 	tx[i++] = (uint8_t)(0xff & (addr      ));
 
-	memcpy(tx+addr_len, data, len);
+	memcpy(tx.data()+addr_len, data, len);
 
 	if (write_enable() == -1)
 		return -1;
 
-	_spi->spi_put(write_cmd, tx, NULL, len+addr_len);
+	_spi->spi_put(write_cmd, tx.data(), NULL, len+addr_len);
 	return _spi->spi_wait(FLASH_RDSR, FLASH_RDSR_WIP, 0x00, 1000);
 }
 
@@ -304,8 +305,9 @@ int SPIFlash::read(int base_addr, uint8_t *data, int len)
 		read_cmd = FLASH_4READ;
 	}
 
-	uint8_t tx[len+addr_len];
-	uint8_t rx[len+addr_len];
+	std::vector<uint8_t> tx, rx;
+	tx.resize(len+addr_len);
+	rx.resize(len+addr_len);
 
 	if (read_cmd == FLASH_4READ)
 		tx[i++] = (uint8_t)(0xff & (base_addr >> 24));
@@ -313,9 +315,9 @@ int SPIFlash::read(int base_addr, uint8_t *data, int len)
 	tx[i++] = (uint8_t)(0xff & (base_addr >>  8));
 	tx[i++] = (uint8_t)(0xff & (base_addr      ));
 
-	int ret = _spi->spi_put(read_cmd, tx, rx, len+addr_len);
+	int ret = _spi->spi_put(read_cmd, tx.data(), rx.data(), len+addr_len);
 	if (ret == 0)
-		memcpy(data, rx+addr_len, len);
+		memcpy(data, rx.data()+addr_len, len);
 	else
 		printf("error\n");
 	return ret;

--- a/src/xilinx.cpp
+++ b/src/xilinx.cpp
@@ -854,7 +854,8 @@ void Xilinx::program_mem(ConfigBitstreamParser *bitfile)
 {
 	std::cout << "load program" << std::endl;
 	unsigned char *tx_buf;
-	unsigned char rx_buf[(_irlen >> 3) + 1];
+	std::vector<unsigned char> rx_buf;
+	rx_buf.resize((_irlen >> 3) + 1);
 
 	/*            comment                                TDI   TMS TCK
 	 * 1: On power-up, place a logic 1 on the TMS,
@@ -879,7 +880,7 @@ void Xilinx::program_mem(ConfigBitstreamParser *bitfile)
 	/* Poll INIT_B (bit 4 of IR capture) until config memory is cleared */
 	tx_buf = get_ircode(_ircode_map, "BYPASS");
 	do {
-		_jtag->shiftIR(tx_buf, rx_buf, _irlen);
+		_jtag->shiftIR(tx_buf, rx_buf.data(), _irlen);
 	} while (!(rx_buf[0] & 0x10));
 	/*
 	 * 8: Move into the RTI state.                        X     0   10,000(1)
@@ -978,7 +979,7 @@ void Xilinx::program_mem(ConfigBitstreamParser *bitfile)
 		*/
 		_jtag->go_test_logic_reset();
 		/* Some xc7s50 does not detect correct connected flash w/o this shift*/
-		_jtag->shiftIR(tx_buf, rx_buf, _irlen);
+		_jtag->shiftIR(tx_buf, rx_buf.data(), _irlen);
 		uint8_t ir_c = rx_buf[0] & 0x03;
 		uint8_t isc_done = ((rx_buf[0] >> 2) & 0x01);
 		uint8_t isc_ena  = ((rx_buf[0] >> 3) & 0x01);
@@ -2182,10 +2183,12 @@ int Xilinx::spi_put(uint8_t cmd,
 		return spi_put_v2(cmd, tx, rx, len);
 
 	int xfer_len = len + 1 + ((rx == NULL) ? 0 : 1);
-	uint8_t jtx[xfer_len];
+	std::vector<uint8_t> jtx;
+	jtx.resize(xfer_len);
 	jtx[0] = McsParser::reverseByte(cmd);
 	/* uint8_t jtx[xfer_len] = {McsParser::reverseByte(cmd)}; */
-	uint8_t jrx[xfer_len];
+	std::vector<uint8_t> jrx;
+	jrx.resize(xfer_len);
 	if (tx != NULL) {
 		for (uint32_t i=0; i < len; i++)
 			jtx[i+1] = McsParser::reverseByte(tx[i]);
@@ -2196,7 +2199,7 @@ int Xilinx::spi_put(uint8_t cmd,
 	 * in the same time store each byte
 	 * to next
 	 */
-	_jtag->shiftDR(jtx, (rx == NULL)? NULL: jrx, 8*xfer_len);
+	_jtag->shiftDR(jtx.data(), (rx == NULL)? NULL: jrx.data(), 8*xfer_len);
 
 	if (rx != NULL) {
 		for (uint32_t i=0; i < len; i++)
@@ -2208,8 +2211,9 @@ int Xilinx::spi_put(uint8_t cmd,
 int Xilinx::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 {
 	int xfer_len = len + ((rx == NULL) ? 0 : 1);
-	uint8_t jtx[xfer_len];
-	uint8_t jrx[xfer_len];
+	std::vector<uint8_t> jtx, jrx;
+	jtx.resize(xfer_len);
+	jrx.resize(xfer_len);
 	if (tx != NULL) {
 		for (uint32_t i=0; i < len; i++)
 			jtx[i] = McsParser::reverseByte(tx[i]);
@@ -2220,7 +2224,7 @@ int Xilinx::spi_put(const uint8_t *tx, uint8_t *rx, uint32_t len)
 	 * in the same time store each byte
 	 * to next
 	 */
-	_jtag->shiftDR(jtx, (rx == NULL)? NULL: jrx, 8*xfer_len);
+	_jtag->shiftDR(jtx.data(), (rx == NULL)? NULL: jrx.data(), 8*xfer_len);
 
 	if (rx != NULL) {
 		for (uint32_t i=0; i < len; i++)
@@ -2288,8 +2292,9 @@ int Xilinx::spi_put_v2(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 
 	const uint32_t xfer_bit_len = (kPktLen - 1) * 8 + (rx ? 8 : 1);
 
-	uint8_t jrx[kPktLen];
-	uint8_t pkt[kPktLen];
+	std::vector<uint8_t> jrx, pkt;
+	jrx.resize(kPktLen);
+	pkt.resize(kPktLen);
 	uint32_t idx = 0;
 
 	pkt[idx++] = ((0x1f & real_len) << 3) | ((0x03 & mode) << 1) | 1;
@@ -2307,7 +2312,7 @@ int Xilinx::spi_put_v2(uint8_t cmd, const uint8_t *tx, uint8_t *rx,
 
 	/* addr BSCAN user1 */
 	_jtag->shiftIR(get_ircode(_ircode_map, _user_instruction), NULL, _irlen);
-	_jtag->shiftDR(pkt, (rx == NULL) ? NULL : jrx, xfer_bit_len);
+	_jtag->shiftDR(pkt.data(), (rx == NULL) ? NULL : jrx.data(), xfer_bit_len);
 	_jtag->go_test_logic_reset();
 	_jtag->flush();
 


### PR DESCRIPTION
While they are in C99, they are not technically standard C++, and MSVC does not aim to support C99.

refs #704