### PR TITLE
Add toolchain file to optimize MSVC-based release builds

### DIFF
--- a/cmake/Toolchain-x86_64-w64-msvc-redist.cmake
+++ b/cmake/Toolchain-x86_64-w64-msvc-redist.cmake
@@ -1,0 +1,30 @@
+# Optimize for small, fast, and dependency-free exes
+
+if (VCPKG_TARGET_TRIPLET AND NOT VCPKG_TARGET_TRIPLET MATCHES "-static$")
+  message(FATAL_ERROR "${CMAKE_CURRENT_LIST_FILE} requires a -static vcpkg triplet")
+endif()
+
+# We're going to use the 'Hybrid CRT' approach, which is the combination of the
+# UCRT and the static C++ Runtime
+#
+# https://github.com/microsoft/WindowsAppSDK/blob/main/docs/Coding-Guidelines/HybridCRT.md
+#
+# In Linux terms, this is roughly equivalent to dynamically linking libc but statically linking libc++
+#
+# This gets us roughly the portability of a static build, but with nearly none of the size cost
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>>")
+add_compile_options("/MT$<$<CONFIG:Debug>:d>")
+add_link_options(
+  "/DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib"
+  "/NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib")
+
+# RelWithDebInfo is nice as then we still get symbols for our release builds (in a separate PDB file)
+# However, MSVC has a bunch of optimizations that are only turned on for plain release builds. Turn
+# them back on for everything except DEBUG. This gets us a smaller and faster binary
+add_link_options(
+  "$<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>"
+  # COMDAT folding
+  "$<$<NOT:$<CONFIG:Debug>>:/OPT:ICF>"
+  # Remove unused functions and data
+  "$<$<NOT:$<CONFIG:Debug>>:/OPT:REF>"
+)


### PR DESCRIPTION
- use 'hybrid CRT' to keep it dependency-free on Win10+ without the full size of static linking
- add default MSVC release optimizations to RelWithDebInfo

refs #704

---

Testing:

```
cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=D:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=D:/openfpgaloader/cmake/Toolchain-x86_64-w64-msvc-redist.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static

cmake --build . --parallel --config RelWithDebInfo
```

On my v1.1.1 branch, this gets me a 2.5MB exe that only depends on:
- `WS2_32.dll` (winsock2, specifically `ntohs()`
- `KERNEL32.dll`
- `ucrtbase.dll` (~ libc)

... and also gives me ~ 20MB of debug symbols, separate to the exe:

<img width="2763" height="1415" alt="image" src="https://github.com/user-attachments/assets/90897a75-d5ef-4ca6-9aae-83c703aa84ce" />

I then used this to re-flash a ModRetro Chromatic with customized firmware:

<img width="2253" height="1053" alt="image" src="https://github.com/user-attachments/assets/5a9c3a4c-c237-41fa-bb47-216aa9928cea" />