### PR TITLE
docs: document DE10-lite MAX 10 support

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -158,6 +158,7 @@ Altera:
       - 10M08
       - 10M16
       - 10M25
+      - 10M50
     URL: https://www.intel.fr/content/www/fr/fr/products/details/fpga/max/10.html
     Memory: SVF
     Flash: POF

--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -374,6 +374,7 @@
   URL: https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=218&No=1021&PartNo=1
   FPGA: MAX 10 10M50DAF484C7G
   Memory: OK
+  Flash: IF
 
 - ID: de10nano
   Description: Terasic de10Nano

--- a/doc/vendors/intel.rst
+++ b/doc/vendors/intel.rst
@@ -89,6 +89,7 @@ Supported Boards:
 
 * step-max10_v1
 * analogMax
+* de10lite
 
 Supported File Types:
 


### PR DESCRIPTION
Clarify support for DE10-lite board and MAX 10 10M50 device. The board was already listed as supported, but max 10 guide / public device list did not include 10M50.

Closes: #675 