### PR TITLE
add Terasic DE23-Lite volatile programming support

### DIFF
--- a/doc/boards.yml
+++ b/doc/boards.yml
@@ -388,6 +388,13 @@
   FPGA: Cyclone V SoC 5CSEMA5F31C6
   Memory: OK
 
+- ID: de23lite
+  Description: Terasic DE23-Lite
+  URL: https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&No=1383
+  FPGA: Altera Agilex 3 A3CZ135BB18AE7S
+  Memory: RBF
+  Flash: NT
+
 - ID: deca
   Description: Arrow/Terasic DECA
   URL: https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=&No=944&PartNo=1

--- a/doc/vendors/intel.rst
+++ b/doc/vendors/intel.rst
@@ -12,6 +12,7 @@ Intel/Altera
   * C10LP-RefKit
   * DE0
   * de0nano
+  * DE23-Lite
 
 Loading a bitstream
 -------------------
@@ -50,7 +51,21 @@ file load:
     # or
     openFPGALoader -b boardname project_name.rbf
 
-with ``boardname`` = ``de0``, ``cyc1000``, ``c10lp-refkit``, ``de0nano``, ``de0nanoSoc`` or ``qmtechCycloneV``.
+with ``boardname`` = ``de0``, ``cyc1000``, ``c10lp-refkit``, ``de0nano``, ``de0nanoSoc``, ``de23lite`` or ``qmtechCycloneV``.
+
+.. NOTE::
+  Agilex 3 and Agilex 5 devices, including the DE23-Lite, must use an
+  uncompressed ``rbf`` file for SRAM configuration. SVF loading is not
+  supported for these devices.
+
+  Quartus Prime Pro 26.1 does not generate RBF files as part of the compilation
+  flow and does not support Agilex 3 with ``quartus_cpf``. Generate and check
+  the RBF with the Programming File Generator instead:
+
+  .. code-block:: bash
+
+      quartus_pfg -c project_name.sof project_name.rbf
+      quartus_pfg --check_integrity project_name.rbf
 
 SPI flash
 ---------

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -162,6 +162,7 @@ static std::map <std::string, target_board_t> board_list = {
 	JTAG_BOARD("de10lite",        "",                     "usb-blaster",  SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("de10nano",        "",                     "usb-blasterII", SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("de1Soc",          "5CSEMA5",              "usb-blasterII", SPI_FLASH, 0, 0, CABLE_DEFAULT),
+	JTAG_BOARD("de23lite",        "A3CZ135BB18AE7S",      "usb-blasterIII", SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("deca",            "10M50DA",              "usb-blasterII", SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("dragonL",         "xc6slx25tcsg324",      "",             SPI_FLASH, 0, 0, CABLE_DEFAULT),
 	JTAG_BOARD("ecp5_evn",        "",                     "ft2232",       SPI_FLASH, 0, 0, CABLE_DEFAULT),


### PR DESCRIPTION
Adds volatile programming support for the Terasic DE23-lite board. It has an Agilex 3 `A3CZ135BB18AE7S` and onboard USB-Blaster III. Both USB Blaster III and Agilex 3 programming already supported by openFPGALoader, so this change just adds the board and device metadata needed to use, as follows:

```sh
openFPGALoader --board de23lite design.rbf
```

Note: I haven't managed to get persistent (non-volatile) flash programming for the board working unfortunately, as there appears to be no publicly accessible documentation as to how the `packet_send_command` from the sdm debug toolkit is implemented by Quartus over raw JTAG.

### Summary of changes:

* Added the `de23lite` board entry using `A3CZ135BB18AE7S` and `usb-blasterIII` to `src/board.hpp`
* Added DE23-lite entry under `doc/boards.yaml`
* Added DE23-lite to list of supported boards in `docs/vendors/intel.rst`
* Added instructions to generate uncompressed `.rbf` file using Quartus Prime Pro `quartus_pgm` to `docs/vendors/intel.rst`

## Validation:

Tested on a physical DE23-lite, with design artifacts generated by Quartus Prime Pro 26.1.0 Build 110.

Board Detection:

```sh
$ ./build/openFPGALoader --board de23lite --detect
Jtag frequency : requested 6.00MHz    -> real 6.00MHz   
index 0:
        idcode 0x436db0dd
        manufacturer altera
        family agilex 3
        model  A3CZ135
        irlength 10
```

Programming:

```sh
$ ./build/openFPGALoader --board de23lite ~/Desktop/test-agilex3/output_files/test.rbf
Jtag frequency : requested 6.00MHz    -> real 6.00MHz   
Load SRAM: [==================================================] 100.00%
Done
```

Visually, the board was behaving as expected after programming. Verifying configuration status using `quartus_pgm` confirms:

```sh
$ quartus_pgm -c "DE23-Lite [3-7-iface0]" -m jtag --device=1 --status --status_type=CONFIG
Info: *******************************************************************
Info: Running Quartus Prime Programmer
    Info: Version 26.1.0 Build 110 03/26/2026 SC Pro Edition
    Info: Copyright (C) 2026  Altera Corporation. All rights reserved.
    Info: Your use of Altera Corporation's design tools, logic functions 
    Info: and other software and tools, and any partner logic 
    Info: functions, and any output files from any of the foregoing 
    Info: (including device programming or simulation files), and any 
    Info: associated documentation or information are expressly subject 
    Info: to the terms and conditions of the Altera Program License 
    Info: Subscription Agreement, the Altera Quartus Prime License Agreement,
    Info: the Altera IP License Agreement, or other applicable license
    Info: agreement, including, without limitation, that your use is for
    Info: the sole purpose of programming logic devices manufactured by
    Info: Altera and sold by Altera or its authorized distributors.  Please
    Info: refer to the Altera Software License Subscription Agreements 
    Info: on the Quartus Prime software download page.
    Info: Processing started: Sat Aug 22 17:56:09 2026
    Info: System process ID: 2062329
Info: Command: quartus_pgm -c "DE23-Lite [3-7-iface0]" -m jtag --device=1 --status --status_type=CONFIG
Info (213045): Using programming cable "DE23-Lite [3-7-iface0]"
Info (21597): Response of CONFIG_STATUS
                Device has entered user mode
                00006000  RESPONSE_CODE=OK, LENGTH=6
                00000000  STATE=IDLE
                001A0100  Version
                C0000049  MSEL=AS_FAST_POR, nSTATUS=1, nCONFIG=1, CLOCK_SOURCE=INTERNAL_OSC
                00000003  CONF_DONE=1, INIT_DONE=1, CVP_DONE=0, SEU_ERROR=0
                00000000  Error location
                0000000F  Error details

Info: Quartus Prime Programmer was successful. 0 errors, 0 warnings
    Info: Peak virtual memory: 586 megabytes
    Info: Processing ended: Sat Aug 22 17:56:10 2026
    Info: Elapsed time: 00:00:01
    Info: System process ID: 2062329
```

Quartus reports `CONF_DONE=1`, `INIT_DONE=1`, and no `SEU_ERROR`.

After programming, the board remained accessible:

```sh
$ ./build/openFPGALoader --board de23lite --detect
Jtag frequency : requested 6.00MHz    -> real 6.00MHz   
index 0:
        idcode 0x436db0dd
        manufacturer altera
        family agilex 3
        model  A3CZ135
        irlength 10
```

Tested on both Ubuntu 24.04 LTS (Intel, x86) (`openFPGAloader` to program + `quartus_pgm` to verify), and an M4 Macbook Pro (`openFPGAloader` to program only, no `quartus_pgm` to verify as Quartus Prime Pro is not supported on Apple Silicon).