### PR TITLE
XVC works in Windows. add 3 cables in XVC client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,19 @@ option(WINDOWS_STATIC_ZLIB "Link zlib statically for Windows builds"            
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 	set(ENABLE_UDEV OFF)
+	# NOTE: WIN32_LEAN_AND_MEAN is needed to avoid a <windows.h>/
+	# <winsock2.h> ordering conflict ("Please include winsock2.h before
+	# windows.h"), but only in translation units that pull in both
+	# Winsock (via src/xvc_sockcompat.hpp) and <windows.h> (via
+	# libusb.h, transitively included by cable.hpp/jtag.hpp/
+	# libusb_ll.hpp). It's defined locally, guarded by #ifndef, at the
+	# top of src/xvc_sockcompat.hpp itself -- scoped to exactly the
+	# files that include it (xvc_client.cpp, xvc_server.cpp, main.cpp,
+	# jtag.cpp), rather than globally for every Windows translation
+	# unit. Defining it globally here as well previously affected
+	# unrelated files too (e.g. ch347jtag.cpp), which is unnecessary
+	# and was suspected of interacting badly with libusb's Windows
+	# backend under sustained USB traffic.
 else()
 	option(ENABLE_UDEV "use udev to search JTAG adapter from /dev/xx" ON)
 endif()
@@ -69,15 +82,16 @@ endif()
 
 option(ENABLE_XILINX_PLATFORM_CABLE_USB "enable Xilinx Platform Cable USB (XPCU) support" ${ENABLE_CABLE_ALL})
 
-# XVC and RemoteBitbang are not available on Windows OS.
+# XVC client/server now build on Windows too: src/xvc_client.* and
+# src/xvc_server.* use a small Winsock2 portability shim
+# (src/xvc_sockcompat.hpp) so they no longer require POSIX sockets.
+# RemoteBitbang stays POSIX-only (unrelated to XVC).
+option(ENABLE_XILINX_VIRTUAL_CABLE_CLIENT "enable Xilinx Virtual Cable (XVC) client support" ${ENABLE_CABLE_ALL})
+option(ENABLE_XILINX_VIRTUAL_CABLE_SERVER "enable Xilinx Virtual Cable (XVC) server support" ${ENABLE_CABLE_ALL})
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-	option(ENABLE_REMOTEBITBANG               "enable remote bitbang driver"              ${ENABLE_CABLE_ALL})
-	option(ENABLE_XILINX_VIRTUAL_CABLE_CLIENT "enable Xilinx Virtual Cable (XVC) client support" ${ENABLE_CABLE_ALL})
-	option(ENABLE_XILINX_VIRTUAL_CABLE_SERVER "enable Xilinx Virtual Cable (XVC) server support" ${ENABLE_CABLE_ALL})
+	option(ENABLE_REMOTEBITBANG "enable remote bitbang driver" ${ENABLE_CABLE_ALL})
 else()
-	set(ENABLE_REMOTEBITBANG               OFF)
-	set(ENABLE_XILINX_VIRTUAL_CABLE_CLIENT OFF)
-	set(ENABLE_XILINX_VIRTUAL_CABLE_SERVER OFF)
+	set(ENABLE_REMOTEBITBANG OFF)
 endif()
 
 ####################################################################################################
@@ -804,7 +818,9 @@ endif()
 
 if (ENABLE_XILINX_VIRTUAL_CABLE_CLIENT)
 	add_definitions(-DENABLE_XVC_CLIENT=1)
-	set(CMAKE_EXE_LINKER_FLAGS "-pthread ${CMAKE_EXE_LINKER_FLAGS}")
+	if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+		set(CMAKE_EXE_LINKER_FLAGS "-pthread ${CMAKE_EXE_LINKER_FLAGS}")
+	endif()
 	message("Xilinx Virtual Client support enabled")
 else()
 	message("Xilinx Virtual Client support disabled")
@@ -812,7 +828,9 @@ endif()
 
 if (ENABLE_XILINX_VIRTUAL_CABLE_SERVER)
 	add_definitions(-DENABLE_XVC_SERVER=1)
-	set(CMAKE_EXE_LINKER_FLAGS "-pthread ${CMAKE_EXE_LINKER_FLAGS}")
+	if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+		set(CMAKE_EXE_LINKER_FLAGS "-pthread ${CMAKE_EXE_LINKER_FLAGS}")
+	endif()
 	message("Xilinx Virtual Server support enabled")
 else()
 	message("Xilinx Virtual Server support disabled")

--- a/src/ch347jtag.cpp
+++ b/src/ch347jtag.cpp
@@ -435,3 +435,77 @@ int CH347Jtag::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 	}
 	return len;
 }
+
+bool CH347Jtag::writeTMSTDI(const uint8_t *tms, const uint8_t *tdi,
+		uint8_t *tdo, uint32_t len)
+{
+	if (len == 0)
+		return true;
+
+	/* make sure obuf/the deferred-write queue is empty before we start
+	 * building our own "CMD_BITS_WR" packets by hand below. */
+	flush();
+
+	/* one CMD_BITS_WR packet: 3 header bytes + 2 bytes/bit (state,
+	 * state|TCK) + 1 trailing byte to release TCK, all within
+	 * MAX_BUFFER; the device replies with 3 header bytes + 1 TDO byte
+	 * per bit, also within MAX_BUFFER. */
+	const uint32_t max_bits_chunk = (MAX_BUFFER - 4) / 2;
+
+	uint32_t bit_pos = 0;
+	while (bit_pos < len) {
+		uint32_t chunk_bits = len - bit_pos;
+		if (chunk_bits > max_bits_chunk)
+			chunk_bits = max_bits_chunk;
+
+		uint8_t *ptr = obuf;
+		*ptr++ = CMD_BITS_WR;
+		ptr += 2;  // length placeholder, filled in below
+
+		uint8_t last_val = 0;
+		for (uint32_t i = 0; i < chunk_bits; ++i) {
+			uint32_t bit = bit_pos + i;
+			uint8_t tms_bit = (tms[bit >> 3] >> (bit & 7)) & 1;
+			uint8_t tdi_bit = (tdi[bit >> 3] >> (bit & 7)) & 1;
+			_tms = tms_bit ? SIG_TMS : 0;
+			_tdi = tdi_bit ? SIG_TDI : 0;
+			last_val = _tms | _tdi;
+			*ptr++ = last_val;
+			*ptr++ = last_val | SIG_TCK;
+		}
+		*ptr++ = last_val;  // release TCK, hold final TMS/TDI state
+
+		unsigned wlen = ptr - obuf;
+		obuf[1] = wlen - 3;
+		obuf[2] = (wlen - 3) >> 8;
+
+		unsigned actual_length = 0;
+		int ret = usb_xfer(wlen, chunk_bits + 3, &actual_length, false);
+		if (ret < 0) {
+			printError(std::string("writeTMSTDI: usb bulk transfer failed: ")
+				+ std::string(libusb_strerror(static_cast<libusb_error>(ret))));
+			return false;
+		}
+
+		unsigned size = ibuf[1] + ibuf[2] * 0x100;
+		if (ibuf[0] != CMD_BITS_WR || actual_length - 3 != size
+				|| size != chunk_bits) {
+			printError("writeTMSTDI: invalid read data");
+			return false;
+		}
+
+		if (tdo) {
+			for (uint32_t i = 0; i < size; ++i) {
+				uint32_t bit = bit_pos + i;
+				if (ibuf[3 + i] == 0x01)
+					tdo[bit >> 3] |= (1 << (bit & 7));
+				else
+					tdo[bit >> 3] &= ~(1 << (bit & 7));
+			}
+		}
+
+		bit_pos += chunk_bits;
+	}
+
+	return true;
+}

--- a/src/ch347jtag.hpp
+++ b/src/ch347jtag.hpp
@@ -21,6 +21,10 @@ class CH347Jtag : public JtagInterface {
 	int writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer, const uint8_t tdi = 1) override;
 	/* TDI */
 	int writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end) override;
+	/* combined TMS+TDI shift with TDO capture, used by the XVC server */
+	bool writeTMSTDI(const uint8_t *tms, const uint8_t *tdi, uint8_t *tdo,
+			uint32_t len) override;
+	bool hasNativeTMSTDI() const override { return true; }
 	/* clk */
 	int toggleClk(uint8_t tms, uint8_t tdo, uint32_t clk_len) override;
 

--- a/src/dirtyJtag.cpp
+++ b/src/dirtyJtag.cpp
@@ -400,7 +400,14 @@ int DirtyJtag::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 			}
 		}
 	}
-	return EXIT_SUCCESS;
+	/* JtagInterface::writeTDI() contract: return len on success (not
+	 * EXIT_SUCCESS/0). Jtag::read_write(), the only caller in the
+	 * normal (non-XVC) flow, discards this return value entirely, so
+	 * this never surfaced there -- but XVC_server::generic_writeTMSTDI()
+	 * does check it strictly, and returning 0 here made every single
+	 * shift look like a failure to it, even on a fully successful
+	 * transfer. */
+	return len;
 }
 
 /* GPIO helpers */

--- a/src/ftdiJtagMPSSE.hpp
+++ b/src/ftdiJtagMPSSE.hpp
@@ -77,6 +77,7 @@ class FtdiJtagMPSSE : public JtagInterface, public FTDIpp_MPSSE {
 	 */
 	bool writeTMSTDI(const uint8_t *tms, const uint8_t *tdi, uint8_t *tdo,
 		uint32_t len) override;
+	bool hasNativeTMSTDI() const override { return true; }
 	/*!
 	 * \brief return internal buffer size (in byte).
 	 * \return _buffer_size -3 for mpsse cmd + size, -1 for potential SEND_IMMEDIATE

--- a/src/jlink.hpp
+++ b/src/jlink.hpp
@@ -66,6 +66,7 @@ class Jlink: public JtagInterface {
 		 */
 		virtual bool writeTMSTDI(const uint8_t *tms, const uint8_t *tdi,
 				uint8_t *tdo, uint32_t numbits) override;
+		bool hasNativeTMSTDI() const override { return true; }
 
 		/*!
 		 * \brief send a serie of clock cycle with constant TMS and TDI

--- a/src/jtag.cpp
+++ b/src/jtag.cpp
@@ -3,6 +3,16 @@
  * Copyright (C) 2020 Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>
  */
 
+#if defined(_WIN32) && defined(ENABLE_XVC_CLIENT)
+/* winsock2.h (pulled in by xvc_sockcompat.hpp) must be included before
+ * windows.h. Several cable headers included below (anlogicCable.hpp,
+ * ftdiJtagMPSSE.hpp, jlink.hpp, ...) transitively include <windows.h>
+ * through libusb.h or libftdi's ftdi.h, no matter where xvc_client.hpp
+ * itself appears in this file. Force this header first, unconditionally,
+ * so winsock2.h always wins the race. */
+#include "xvc_sockcompat.hpp"
+#endif
+
 #include <cstring>
 #include <iomanip>
 #include <iostream>

--- a/src/jtagInterface.hpp
+++ b/src/jtagInterface.hpp
@@ -77,6 +77,32 @@ class JtagInterface {
 			uint8_t *tdo, uint32_t len)
 	{ (void)tms; (void)tdi; (void)tdo; (void)len; return false;}
 	/*!
+	 * \brief tells whether writeTMSTDI() above is a genuine
+	 *        hardware-level combined TMS+TDI operation for this cable,
+	 *        or just the inherited no-op stub. Used by the XVC server
+	 *        to pick between the fast native path and a slower,
+	 *        universal software fallback built on top of
+	 *        writeTMS()/writeTDI() (see
+	 *        XVC_server::generic_writeTMSTDI()), which every cable
+	 *        supports since both are pure virtual here.
+	 * \return true when writeTMSTDI() actually talks to the hardware
+	 */
+	virtual bool hasNativeTMSTDI() const { return false; }
+	/*!
+	 * \brief optional safety cap, in Hz, on the clock frequency the
+	 *        XVC server should ever request from this cable via
+	 *        setClkFreq(), regardless of what an XVC client (e.g.
+	 *        Vivado, via its own internal negotiation) asks for. Some
+	 *        cable/wiring combinations are less tolerant of high JTAG
+	 *        clock rates than others, and unlike direct (non-XVC) use
+	 *        -- where the frequency is under the user's own control on
+	 *        the command line -- an XVC client typically picks its own
+	 *        frequency without exposing it to the user. Return 0 (the
+	 *        default) for "no cap, honor whatever the client asks
+	 *        for".
+	 */
+	virtual uint32_t maxSafeXvcFreq() const { return 0; }
+	/*!
 	 * \brief toggle clk without touch of TDI/TMS
 	 * \param tms: state of tms signal
 	 * \param tdi: state of tdi signal

--- a/src/libgpiodJtagBitbang.hpp
+++ b/src/libgpiodJtagBitbang.hpp
@@ -38,6 +38,7 @@ class LibgpiodJtagBitbang : public JtagInterface {
 	int toggleClk(uint8_t tms, uint8_t tdo, uint32_t clk_len) override;
 	bool writeTMSTDI(const uint8_t *tms, const uint8_t *tdi, uint8_t *tdo,
 			 uint32_t len) override;
+	bool hasNativeTMSTDI() const override { return true; }
 
 	int get_buffer_size() override { return 0; }
 	bool isFull() override { return false; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,16 @@
  * Copyright (C) 2019 Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>
  */
 
+#if defined(_WIN32) && (defined(ENABLE_XVC_CLIENT) || defined(ENABLE_XVC_SERVER))
+/* winsock2.h (pulled in by xvc_sockcompat.hpp) must be included before
+ * windows.h. Several vendor cable headers included below (dfu.hpp,
+ * libusb_ll.hpp, ftdiJtagMPSSE.hpp via jtag.hpp, ...) transitively
+ * include <windows.h> through libusb.h or libftdi's ftdi.h, no matter
+ * where xvc_server.hpp itself appears in this file. Force this header
+ * first, unconditionally, so winsock2.h always wins the race. */
+#include "xvc_sockcompat.hpp"
+#endif
+
 #include <string.h>
 #include <unistd.h>
 

--- a/src/usbBlaster.cpp
+++ b/src/usbBlaster.cpp
@@ -42,7 +42,17 @@
 UsbBlaster::UsbBlaster(const cable_t &cable, const std::string &firmware_path,
 		int8_t verbose):
 			_verbose(verbose > 1), _nb_bit(0),
-			_curr_tms(0), _buffer_size(64),
+			/* Bumped from the original 64 to 1024: confirmed working
+			 * on real USB-BlasterI hardware by the user. Values
+			 * above 1024 caused USB read timeouts on that same
+			 * hardware (the classic FT245 "sync FIFO" protocol
+			 * doesn't sustain much larger write+read transactions
+			 * reliably) -- do not raise this further without
+			 * retesting on real hardware. Note the two `> 64`
+			 * checks a bit further down in this file are left
+			 * exactly as in upstream (not switched to _buffer_size)
+			 * on purpose, matching exactly what was tested. */
+			_curr_tms(0), _buffer_size(1024),
 			_passive_serial_mode(false)
 {
 	if (cable.pid == 0x6001 || cable.pid == 0x6002 || cable.pid == 0x6003)
@@ -169,6 +179,44 @@ int UsbBlaster::writeTDI(const uint8_t *tx, uint8_t *rx, uint32_t len, bool end)
 	 */
 	_in_buf[_nb_bit++] = DEFAULT | DO_BITBB | DO_WRITE | _curr_tms;
 	flush();
+
+	if (_curr_tms != 0 && nb_byte != 0) {
+		/* The fast DO_SHIFT path below does not touch the TMS pin at
+		 * all: it only shifts data while relying on TMS already
+		 * being physically driven low by some earlier bit-banged
+		 * write, tracked here as _curr_tms. When that isn't true --
+		 * e.g. a caller (such as the XVC server's generic TMS+TDI
+		 * fallback) invokes writeTDI() right after a run of pure
+		 * TMS=1 bits, with no intervening writeTMS() call ending on
+		 * tms=0 -- using DO_SHIFT directly would leave the TAP
+		 * outside SHIFT-DR/IR and produce garbage. An earlier version
+		 * of this fix bit-banged the *entire* byte-aligned portion in
+		 * that case (safe, but slow: 2 bytes of USB traffic per bit
+		 * instead of DO_SHIFT's 1:1). Priming with just the first
+		 * byte here is enough: it's bit-banged (still explicitly
+		 * driving TMS=0 for every one of its bits, still capturing
+		 * its TDO correctly -- unlike the very first, buggy version
+		 * of this fix, which silently dropped this data instead), and
+		 * once it's done the wire is genuinely at TMS=0, so the
+		 * *rest* of the byte-aligned data (if any) can go through the
+		 * normal fast DO_SHIFT loop just below, restoring full speed
+		 * for everything but that first byte. */
+		uint8_t mask = DEFAULT | DO_BITBB;
+		for (uint32_t k = 0; k < 8; k++) {
+			uint8_t val = 0;
+			if (tx)
+				val |= ((tx_ptr[0] & (1 << k))? _tdi_pin : 0);
+			_in_buf[_nb_bit++] = mask | val;
+			_in_buf[_nb_bit++] = mask | mode | val | _tck_pin;
+		}
+		if (writeBit((rx)? rx_ptr:NULL, 8) < 0)
+			return -EXIT_FAILURE;
+		if (rx)
+			rx_ptr += 1;
+		tx_ptr += 1;
+		nb_byte -= 1;
+		_curr_tms = 0;
+	}
 
 	if (_curr_tms == 0 && nb_byte != 0) {
 		uint8_t mask = DO_SHIFT | mode;

--- a/src/xvc_client.cpp
+++ b/src/xvc_client.cpp
@@ -5,15 +5,9 @@
 
 #include "xvc_client.hpp"
 
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <strings.h>
 #include <string.h>
-#include <unistd.h>
 #include <math.h>
 
 #include <map>
@@ -29,9 +23,12 @@
 XVC_client::XVC_client(const std::string &ip_addr, int port,
 		uint32_t clkHz, int8_t verbose):
 	_verbose(verbose > 0), _xfer_buf(NULL), _tms(NULL), _tditdo(NULL),
-	_num_bits(0), _last_tms(0), _last_tdi(0), _buffer_size(0), _sock(0),
-	_port(port)
+	_num_bits(0), _last_tms(0), _last_tdi(0), _buffer_size(0),
+	_sock(INVALID_SOCKET), _port(port)
 {
+	if (!xvc_socket_init())
+		throw std::runtime_error("socket layer initialization failure");
+
 	if (!open_connection(ip_addr))
 		throw std::runtime_error("connection failure");
 
@@ -83,7 +80,8 @@ XVC_client::~XVC_client()
 	if (_tditdo)
 		free(_tditdo);
 	// close socket
-	close(_sock);
+	xvc_close_socket(_sock);
+	xvc_socket_cleanup();
 }
 
 int XVC_client::writeTMS(const uint8_t *tms, uint32_t len, bool flush_buffer,
@@ -224,50 +222,76 @@ int XVC_client::setClkFreq(uint32_t clkHz)
 
 bool XVC_client::open_connection(const std::string &ip_addr)
 {
-	struct sockaddr_in addr;
-	addr.sin_family = AF_INET;
-	addr.sin_port = htons(_port);
-	addr.sin_addr.s_addr = inet_addr(ip_addr.c_str());
+	struct addrinfo hints;
+	struct addrinfo *res = nullptr;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
 
-	_sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-	if (_sock == -1) {
+	/* NOTE: this used to build the sockaddr_in "by hand" with
+	 * inet_addr(ip_addr.c_str()) -- but inet_addr() only understands
+	 * dotted-decimal IP literals ("192.168.1.5"), NOT hostnames. Given
+	 * a hostname it silently fails and returns INADDR_NONE
+	 * (255.255.255.255), and connect()ing to that bogus address is
+	 * what produces "WSA error 10049" (WSAEADDRNOTAVAIL) on Windows
+	 * (and a similar failure on POSIX). getaddrinfo() resolves both
+	 * IP literals and hostnames correctly, on every platform. */
+	int gai_ret = getaddrinfo(ip_addr.c_str(), std::to_string(_port).c_str(),
+			&hints, &res);
+	if (gai_ret != 0) {
+		printError("Address resolution error for \"" + ip_addr + "\": " +
+#if defined(_WIN32) || defined(_WIN64)
+			xvc_last_socket_error());
+#else
+			std::string(gai_strerror(gai_ret)));
+#endif
+		return false;
+	}
+
+	_sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+	if (_sock == INVALID_SOCKET) {
 		printError("Socket creation error");
+		freeaddrinfo(res);
 		return false;
 	}
 
-	if (connect(_sock, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
-		printError("Connection error");
-		close(_sock);
+	if (connect(_sock, res->ai_addr,
+			static_cast<socklen_t>(res->ai_addrlen)) == SOCKET_ERROR) {
+		printError("Connection error: " + xvc_last_socket_error());
+		xvc_close_socket(_sock);
+		freeaddrinfo(res);
 		return false;
 	}
 
+	freeaddrinfo(res);
 	return true;
 }
 
 static
-int sendall(int sock, const void* raw, size_t cnt, int flags)
+long sendall(SOCKET sock, const void* raw, size_t cnt)
 {
-	const char *buf = (const char*)raw;
+	const uint8_t *buf = (const uint8_t*)raw;
 	size_t remaining = cnt;
 	while (remaining) {
-		ssize_t ret = send(sock, buf, remaining, flags);
-		if (ret==0) // should not happen on Linux for a TCP socket
+		long ret = xvc_send(sock, buf, remaining);
+		if (ret==0) // should not happen on a connected TCP socket
 			throw std::logic_error("platform TCP send() returns zero?!?");
 		if (ret < 0)
 			return ret;
 		buf += ret;
 		remaining -= ret;
 	}
-	return cnt; // success
+	return (long)cnt; // success
 }
 
 static
-ssize_t recvall(int sock, void* raw, size_t cnt, int flags)
+ssize_t recvall(SOCKET sock, void* raw, size_t cnt)
 {
-	char *buf = (char*)raw;
+	uint8_t *buf = (uint8_t*)raw;
 	size_t remaining = cnt;
 	while (remaining) {
-		ssize_t ret = recv(sock, buf, remaining, flags);
+		long ret = xvc_recv(sock, buf, remaining);
 		if (ret < 0)
 			return ret;
 		if (ret == 0)  // peer closed the connection mid-reply
@@ -288,19 +312,19 @@ ssize_t XVC_client::xfer_pkt(const std::string &instr,
 	if (tx)
 		memcpy(buffer.data() + instr.size(), tx, tx_size);
 
-	if (sendall(_sock, buffer.data(), buffer.size(), 0) == -1) {
+	if (sendall(_sock, buffer.data(), buffer.size()) == -1) {
 		printError("Send failed");
 		return -1;
 	}
 
 	if (rx) {
 		if (rx_exact) {
-			len = recvall(_sock, rx, rx_size, 0);
+			len = recvall(_sock, rx, rx_size);
 		} else {
-			len = recv(_sock, rx, rx_size, 0);
+			len = xvc_recv(_sock, rx, rx_size);
 		}
 		if (len < 0) {
-			printError("Receive error");
+			printError("Receive error: " + xvc_last_socket_error());
 			return len;
 		} else if (len == 0) {
 			fprintf(stderr, "Client orderly shut down the connection.\n");

--- a/src/xvc_client.hpp
+++ b/src/xvc_client.hpp
@@ -6,6 +6,8 @@
 #ifndef SRC_XVC_CLIENT_HPP_
 #define SRC_XVC_CLIENT_HPP_
 
+#include "xvc_sockcompat.hpp"
+
 #include <string>
 
 #include "jtagInterface.hpp"
@@ -121,7 +123,7 @@ class XVC_client: public JtagInterface {
 		uint32_t _buffer_size;
 		std::string _server_name;
 		std::string _server_vers;
-		int _sock;
+		SOCKET _sock;
 		int _port;                /*!< target port */
 };
 #endif  // SRC_XVC_CLIENT_HPP_

--- a/src/xvc_server.cpp
+++ b/src/xvc_server.cpp
@@ -5,18 +5,23 @@
 
 #include "xvc_server.hpp"
 
-#include <arpa/inet.h>
-#include <sys/socket.h>
-#include <errno.h>
-#include <netinet/tcp.h>
-#include <unistd.h>
-
+#include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <stdexcept>
 
 #include "ftdiJtagMPSSE.hpp"
 #ifdef ENABLE_LIBGPIOD
 #include "libgpiodJtagBitbang.hpp"
+#endif
+#ifdef ENABLE_USBBLASTER
+#include "usbBlaster.hpp"
+#endif
+#ifdef ENABLE_CH347
+#include "ch347jtag.hpp"
+#endif
+#ifdef ENABLE_DIRTYJTAG
+#include "dirtyJtag.hpp"
 #endif
 #include "cable.hpp"
 #include "display.hpp"
@@ -26,8 +31,8 @@ XVC_server::XVC_server(int port, const cable_t & cable,
 	const jtag_pins_conf_t * pin_conf, std::string dev,
 	const std::string & serial, uint32_t clkHZ, int8_t verbose,
 	const std::string & ip_adr, const bool invert_read_edge,
-	const std::string & firmware_path):_verbose(verbose > 1),
-			_jtag(NULL), _port(port), _sock(-1),
+	const std::string & firmware_path):_verbose(verbose > 0),
+			_jtag(NULL), _port(port), _sock(INVALID_SOCKET),
 			_is_stopped(false), _must_stop(false),
 			_buffer_size(1048576), _state(Jtag::RUN_TEST_IDLE)
 {
@@ -42,6 +47,22 @@ XVC_server::XVC_server(int port, const cable_t & cable,
 #ifdef ENABLE_LIBGPIOD
 	case MODE_LIBGPIOD_BITBANG:
 		_jtag = new LibgpiodJtagBitbang(pin_conf, dev, clkHZ, verbose);
+		break;
+#endif
+#ifdef ENABLE_USBBLASTER
+	case MODE_USBBLASTER:
+		_jtag = new UsbBlaster(cable, firmware_path, verbose);
+		break;
+#endif
+#ifdef ENABLE_CH347
+	case MODE_CH347:
+		_jtag = new CH347Jtag(clkHZ, verbose, cable.vid, cable.pid,
+				cable.bus_addr, cable.device_addr);
+		break;
+#endif
+#ifdef ENABLE_DIRTYJTAG
+	case MODE_DIRTYJTAG:
+		_jtag = new DirtyJtag(clkHZ, verbose, cable.vid, cable.pid);
 		break;
 #endif
 #if 0
@@ -59,15 +80,8 @@ XVC_server::XVC_server(int port, const cable_t & cable,
 		_jtag =
 			new CH552_jtag(cable.config, dev, serial, clkHZ, _verbose);
 		break;
-	case MODE_DIRTYJTAG:
-		_jtag = new DirtyJtag(clkHZ, _verbose, cable.vid, cable.pid);
-		break;
 	case MODE_JLINK:
 		_jtag = new Jlink(clkHZ, _verbose);
-		break;
-	case MODE_USBBLASTER:
-		_jtag = new UsbBlaster(cable.config.vid, cable.config.pid,
-					   firmware_path, _verbose);
 		break;
 #ifdef ENABLE_CMSISDAP
 	case MODE_CMSISDAP:
@@ -88,6 +102,7 @@ XVC_server::XVC_server(int port, const cable_t & cable,
 XVC_server::~XVC_server()
 {
 	close_connection();
+	xvc_socket_cleanup();
 	if (_jtag)
 		delete _jtag;
 	free(_tmstdi);
@@ -97,35 +112,43 @@ XVC_server::~XVC_server()
 bool XVC_server::open_connection()
 {
 	char hostname[256];
+
+	if (!xvc_socket_init()) {
+		printError("Socket layer initialization failure");
+		return false;
+	}
+
 	memset(&_sock_addr, '\0', sizeof(_sock_addr));
 	_sock_addr.sin_family = AF_INET;
 	_sock_addr.sin_port = htons(_port);
 	_sock_addr.sin_addr.s_addr = INADDR_ANY;
 
 	_sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-	if (_sock < 0) {
+	if (_sock == INVALID_SOCKET) {
 		printError("Socket creation error");
 		return false;
 	}
 
 	int i = 1;
-	setsockopt(_sock, SOL_SOCKET, SO_REUSEADDR, &i, sizeof i);
+	setsockopt(_sock, SOL_SOCKET, SO_REUSEADDR,
+			reinterpret_cast<const char *>(&i), sizeof i);
 
-	if (::bind(_sock, (struct sockaddr*) &_sock_addr, sizeof(_sock_addr)) < 0) {
-		printError("Socket bind error");
-		close(_sock);
+	if (::bind(_sock, (struct sockaddr*) &_sock_addr, sizeof(_sock_addr))
+			== SOCKET_ERROR) {
+		printError("Socket bind error: " + xvc_last_socket_error());
+		xvc_close_socket(_sock);
 		return false;
 	}
 
-	if (listen(_sock, 1) < 0) {
-		printError("Socket listen error");
-		close(_sock);
+	if (listen(_sock, 1) == SOCKET_ERROR) {
+		printError("Socket listen error: " + xvc_last_socket_error());
+		xvc_close_socket(_sock);
 		return false;
 	}
 
 	if (gethostname(hostname, sizeof(hostname)) != 0) {
 		printError("hostname lookup");
-		close(_sock);
+		xvc_close_socket(_sock);
 		return false;
 	}
 
@@ -140,81 +163,128 @@ bool XVC_server::open_connection()
 
 bool XVC_server::close_connection()
 {
-	if (_sock != -1)
-		close(_sock);
-	_sock = -1;
+	/* Only close the listening socket here: thread_listen() may still be
+	 * servicing already-accepted client connections at this point, so
+	 * Winsock itself (xvc_socket_cleanup()) is only released once the
+	 * thread has fully stopped, see ~XVC_server(). */
+	if (_sock != INVALID_SOCKET)
+		xvc_close_socket(_sock);
+	_sock = INVALID_SOCKET;
 	return true;
 }
 
 void XVC_server::thread_listen()
 {
-	fd_set conn;
-	int maxfd = 0;
-
-	FD_ZERO(&conn);
-	FD_SET(_sock, &conn);
-
-	maxfd = _sock;
+	/* Accepted client connections.
+	 * NOTE: on POSIX a socket fd is a small sequential integer, so the
+	 * original code just scanned every value between 0 and maxfd. On
+	 * Windows a SOCKET is an opaque kernel handle (not a small sequential
+	 * index), so that scan is invalid there. Keeping an explicit list of
+	 * active client sockets works identically -- and is simpler -- on
+	 * both POSIX and Windows, so it is used unconditionally. */
+	std::vector<SOCKET> clients;
 
 	try {
 		while (!_must_stop) {
-			fd_set read = conn, except = conn;
-			int fd;
+			fd_set conn;
+			FD_ZERO(&conn);
+			FD_SET(_sock, &conn);
+			SOCKET maxfd = _sock;
+			for (SOCKET c : clients) {
+				FD_SET(c, &conn);
+				if (c > maxfd)
+					maxfd = c;
+			}
 
+			fd_set read = conn, except = conn;
 			struct timeval tv;
 			tv.tv_sec = 1;
 			tv.tv_usec = 0;
-			if (select(maxfd + 1, &read, 0, &except, &tv) < 0) {
-				printError("select");
+			/* nfds is ignored by Winsock's select(), only fd_set content
+			 * matters there; on POSIX it must be maxfd + 1. */
+#if defined(_WIN32) || defined(_WIN64)
+			int select_ret = select(0, &read, NULL, &except, &tv);
+#else
+			int select_ret = select(static_cast<int>(maxfd) + 1, &read,
+					NULL, &except, &tv);
+#endif
+			if (select_ret == SOCKET_ERROR) {
+				printError("select: " + xvc_last_socket_error());
 				break;
 			}
 
-			for (fd = 0; fd <= maxfd; ++fd) {
-				if (FD_ISSET(fd, &read)) {
-					if (fd == _sock) {
-						int newfd;
-						socklen_t nsize = sizeof(_sock_addr);
+			/* new incoming connection */
+			if (FD_ISSET(_sock, &read)) {
+				socklen_t nsize = sizeof(_sock_addr);
+				SOCKET newfd = accept(_sock, (struct sockaddr*) &_sock_addr,
+						&nsize);
 
-						newfd = accept(_sock, (struct sockaddr*) &_sock_addr,
-							&nsize);
-
-						printf("connection accepted - fd %d\n", newfd);
-						if (newfd < 0) {
-							throw std::runtime_error("accept");
-						} else {
-							printInfo("setting TCP_NODELAY to 1\n");
-							int flag = 1;
-							int optResult = setsockopt(newfd, IPPROTO_TCP,
-									TCP_NODELAY, (char *)&flag, sizeof(int));
-							if (optResult < 0)
-								throw std::runtime_error("TCP_NODELAY error");
-							if (newfd > maxfd) {
-								maxfd = newfd;
-							}
-							FD_SET(newfd, &conn);
-						}
+				if (newfd == INVALID_SOCKET) {
+					/* Transient accept() failures (e.g. the peer
+					 * resets the connection between select() and
+					 * accept()) must not take down the whole
+					 * listening loop -- log and keep serving other
+					 * connections / waiting for the next one. */
+					printError("accept: " + xvc_last_socket_error());
+				} else {
+					printInfo("connection accepted - fd " +
+							std::to_string(static_cast<intptr_t>(newfd)));
+					printInfo("setting TCP_NODELAY to 1\n");
+					int flag = 1;
+					int optResult = setsockopt(newfd, IPPROTO_TCP,
+							TCP_NODELAY, reinterpret_cast<const char *>(&flag),
+							sizeof(int));
+					if (optResult == SOCKET_ERROR) {
+						printError("TCP_NODELAY: " + xvc_last_socket_error());
+						xvc_close_socket(newfd);
 					} else {
-						int ret = handle_data(fd);
-						if (ret != 0) {
-							printInfo("connection closed - fd " + std::to_string(fd));
-							close(fd);
-							FD_CLR(fd, &conn);
-							if (ret == 3)
-								throw std::runtime_error("communication failure");
-						}
+						clients.push_back(newfd);
+					}
+				}
+			}
+
+			/* service existing connections */
+			for (auto it = clients.begin(); it != clients.end();) {
+				SOCKET fd = *it;
+				bool drop = false;
+
+				if (FD_ISSET(fd, &read)) {
+					int ret = handle_data(fd);
+					if (ret != 0) {
+						printInfo("connection closed - fd " +
+								std::to_string(static_cast<intptr_t>(fd)));
+						xvc_close_socket(fd);
+						drop = true;
+						/* NOTE: a communication failure (ret == 3) with
+						 * THIS client must not take down the listening
+						 * loop for every future connection -- it used
+						 * to throw here, which propagated past the
+						 * while() below straight into the catch block,
+						 * silently ending thread_listen() for good:
+						 * the process kept running (main thread still
+						 * blocked on getchar()) but nothing ever
+						 * accept()ed a new connection again, so any
+						 * later client would connect at the TCP level
+						 * and then hang forever waiting for a reply
+						 * that could never come. Just drop this one
+						 * client and keep serving. */
 					}
 				} else if (FD_ISSET(fd, &except)) {
-					printWarn("connection aborted - fd " + std::to_string(fd));
-					close(fd);
-					FD_CLR(fd, &conn);
-					if (fd == _sock)
-						break;
+					printWarn("connection aborted - fd " +
+							std::to_string(static_cast<intptr_t>(fd)));
+					xvc_close_socket(fd);
+					drop = true;
 				}
+
+				it = drop ? clients.erase(it) : std::next(it);
 			}
 		}
 	} catch (const std::runtime_error& e) {
 		std::cerr << "thread exiting with error: " << e.what() << std::endl;
 	}
+
+	for (SOCKET c : clients)
+		xvc_close_socket(c);
 	_is_stopped = true;
 }
 
@@ -234,18 +304,16 @@ bool XVC_server::listen_loop()
 	return true;
 }
 
-int XVC_server::sread(int fd, void *target, int len)
+int XVC_server::sread(SOCKET fd, void *target, int len)
 {
 	unsigned char *t = (unsigned char *)target;
 	while (len) {
-		int r = read(fd, t, len);
+		long r = xvc_recv(fd, t, len);
 		if (r == 0){  // connection closed
 			return 2;
 		} else if (r < 0) {
-			char err[256];
-			snprintf(err, 256, "Read error (%d) %d %s\n", r,
-				errno, strerror(errno));
-			printError(err);
+			printError("Read error (" + std::to_string(r) + ") " +
+					xvc_last_socket_error());
 			return 3;
 		}
 
@@ -255,7 +323,7 @@ int XVC_server::sread(int fd, void *target, int len)
 	return 1;
 }
 
-int XVC_server::handle_data(int fd)
+int XVC_server::handle_data(SOCKET fd)
 {
 	char xvcInfo[32];
 	int ret;
@@ -274,9 +342,9 @@ int XVC_server::handle_data(int fd)
 				return ret;
 			snprintf(xvcInfo, sizeof(xvcInfo),
 				"xvcServer_v1.0:%u\n", _buffer_size);
-			if (send(fd, xvcInfo, strlen(xvcInfo), 0) !=
-				(ssize_t) strlen(xvcInfo)) {
-				perror("write");
+			if (xvc_send(fd, xvcInfo, strlen(xvcInfo)) !=
+				(long) strlen(xvcInfo)) {
+				printError("write: " + xvc_last_socket_error());
 				return 1;
 			}
 			if (_verbose) {
@@ -290,8 +358,8 @@ int XVC_server::handle_data(int fd)
 			if ((ret = sread(fd, cmd, 9)) != 1)
 				return ret;
 			memcpy(_result, cmd + 5, 4);
-			if (write(fd, _result, 4) != 4) {
-				printError("write");
+			if (xvc_send(fd, _result, 4) != 4) {
+				printError("write: " + xvc_last_socket_error());
 				return 1;
 			}
 			uint32_t clk_period =
@@ -300,7 +368,17 @@ int XVC_server::handle_data(int fd)
 				(static_cast<uint32_t>(_result[2]) << 16) |
 				(static_cast<uint32_t>(_result[3]) << 24);
 
-			_jtag->setClkFreq(static_cast<uint32_t>(1e9/clk_period));
+			uint32_t requested_freq = static_cast<uint32_t>(1e9/clk_period);
+			uint32_t safe_max = _jtag->maxSafeXvcFreq();
+			uint32_t actual_freq = (safe_max != 0 && requested_freq > safe_max)
+				? safe_max : requested_freq;
+			if (_verbose && actual_freq != requested_freq) {
+				printInfo("settck: capping requested " +
+						std::to_string(requested_freq) + "Hz to " +
+						std::to_string(actual_freq) +
+						"Hz (cable safety limit)");
+			}
+			_jtag->setClkFreq(actual_freq);
 
 			if (_verbose) {
 				printInfo(std::to_string((int)time(NULL)) +
@@ -371,12 +449,24 @@ int XVC_server::handle_data(int fd)
 				(_state == Jtag::EXIT1_DR && len == 4 && _tmstdi[0] == 0x6b))) {
 			// update state using tms sequence
 			set_state(_tmstdi, len);
-			_jtag->writeTMSTDI(_tmstdi, _tmstdi + nr_bytes, _result, len);
+			if (_jtag->hasNativeTMSTDI()) {
+				if (!_jtag->writeTMSTDI(_tmstdi, _tmstdi + nr_bytes,
+						_result, len)) {
+					printError("writeTMSTDI failed");
+					return 1;
+				}
+			} else {
+				if (!generic_writeTMSTDI(_tmstdi, _tmstdi + nr_bytes,
+						_result, len)) {
+					printError("generic_writeTMSTDI failed");
+					return 1;
+				}
+			}
 		}
 
 		/* send received TDO sequence */
-		if (send(fd, _result, nr_bytes, 0) != nr_bytes) {
-			printError("write");
+		if (xvc_send(fd, _result, nr_bytes) != (long) nr_bytes) {
+			printError("write: " + xvc_last_socket_error());
 			return 1;
 		}
 	} while (1);
@@ -386,6 +476,143 @@ int XVC_server::handle_data(int fd)
 /* loops over tms_seq, extracts bit by bit values and update
  * jtag "virtual" state accordingly.
  */
+/* Extract `nbits` bits starting at bit offset `src_bit_offset` in `src`
+ * (lsb first) into a freshly, tightly-packed buffer `dst` (starting at
+ * bit 0). Used to build the small per-run buffers writeTDI()/writeTMS()
+ * expect out of the middle of the much larger XVC (tms, tdi) vectors. */
+static void xvc_pack_bits(const uint8_t *src, uint32_t src_bit_offset,
+		uint8_t *dst, uint32_t nbits)
+{
+	for (uint32_t i = 0; i < nbits; i++) {
+		uint32_t sbit = src_bit_offset + i;
+		bool bit = (src[sbit >> 3] >> (sbit & 7)) & 1;
+		if (bit)
+			dst[i >> 3] |= (1 << (i & 7));
+		else
+			dst[i >> 3] &= ~(1 << (i & 7));
+	}
+}
+
+/* Reverse of xvc_pack_bits(): copy `nbits` tightly-packed bits from `src`
+ * (starting at bit 0) into `dst` starting at bit offset `dst_bit_offset`
+ * (lsb first). Used to place a run's TDO capture back into the XVC
+ * reply buffer at the right bit position. */
+static void xvc_unpack_bits(const uint8_t *src, uint32_t nbits,
+		uint8_t *dst, uint32_t dst_bit_offset)
+{
+	for (uint32_t i = 0; i < nbits; i++) {
+		uint32_t dbit = dst_bit_offset + i;
+		bool bit = (src[i >> 3] >> (i & 7)) & 1;
+		if (bit)
+			dst[dbit >> 3] |= (1 << (dbit & 7));
+		else
+			dst[dbit >> 3] &= ~(1 << (dbit & 7));
+	}
+}
+
+bool XVC_server::generic_writeTMSTDI(const uint8_t *tms, const uint8_t *tdi,
+		uint8_t *tdo, uint32_t len)
+{
+	if (len == 0)
+		return true;
+
+	uint32_t nbytes = (len + 7) / 8;
+	/* scratch buffer, reused to pack either a TDI run or a TMS run */
+	std::vector<uint8_t> run_buf(nbytes, 0);
+	std::vector<uint8_t> run_tdo(nbytes, 0);
+
+	uint32_t i = 0;
+	while (i < len) {
+		bool bit_tms = (tms[i >> 3] >> (i & 7)) & 1;
+
+		if (!bit_tms) {
+			/* "shift" run: bits with tms==0 (shifting through the
+			 * currently selected data register) followed by, at
+			 * most, a single tms==1 bit that both ends the run and
+			 * exits the shift state -- exactly what writeTDI()'s
+			 * "end" parameter does on its last bit. */
+			uint32_t j = i;
+			while (j < len && !((tms[j >> 3] >> (j & 7)) & 1))
+				j++;
+			uint32_t run_len = j - i;
+			bool end = false;
+			if (j < len) {
+				run_len++;  // absorb the single trailing tms==1 bit
+				end = true;
+			}
+
+			/* NOTE: an earlier version of this function "primed" the
+			 * wire with an explicit tms=0 bit through writeTMS()
+			 * before calling writeTDI() with the rest, to work
+			 * around cables (e.g. UsbBlaster) whose writeTDI() only
+			 * uses its fast byte-oriented path when it already
+			 * believes tms=0 is on the wire. That priming bit had
+			 * no TDO capture (writeTMS() returns none), which is
+			 * only safe if that bit is a throwaway state-entry
+			 * artifact -- true for some XVC clients' message
+			 * framing, but NOT guaranteed in general: a client that
+			 * sends TAP navigation and the data shift as two
+			 * separate "shift:" messages (as openFPGALoader's own
+			 * xvc-client does) can have a shift-run whose very
+			 * first bit is genuine payload (e.g. bit 0 of a 32-bit
+			 * IDCODE read) -- priming silently corrupted exactly
+			 * that bit. Fixed properly instead in
+			 * UsbBlaster::writeTDI() itself, which now handles a
+			 * stale internal TMS-tracking state safely (falls back
+			 * to bit-banging, still capturing TDO, instead of
+			 * silently dropping data) -- so this layer no longer
+			 * needs to work around it at all. */
+			xvc_pack_bits(tdi, i, run_buf.data(), run_len);
+			int ret = _jtag->writeTDI(run_buf.data(), run_tdo.data(),
+					run_len, end);
+			if (ret < 0 || static_cast<uint32_t>(ret) != run_len) {
+				printError("generic_writeTMSTDI: writeTDI failed");
+				return false;
+			}
+			xvc_unpack_bits(run_tdo.data(), run_len, tdo, i);
+
+			i += run_len;
+		} else {
+			/* pure TAP navigation run: tms varies, tdi is not
+			 * meaningfully sampled by real hardware here since the
+			 * TAP is not in a SHIFT-DR/IR state; the XVC reply bits
+			 * for this run are simply left at 0 (already the case,
+			 * _result is memset to 0 by the caller), matching what
+			 * other minimal XVC servers do outside of shift runs. */
+			uint32_t j = i;
+			while (j < len && ((tms[j >> 3] >> (j & 7)) & 1))
+				j++;
+			uint32_t run_len = j - i;
+			bool tdi_bit = (tdi[i >> 3] >> (i & 7)) & 1;
+
+			xvc_pack_bits(tms, i, run_buf.data(), run_len);
+			int ret = _jtag->writeTMS(run_buf.data(), run_len, false,
+					tdi_bit);
+			if (ret < 0 || static_cast<uint32_t>(ret) != run_len) {
+				printError("generic_writeTMSTDI: writeTMS failed");
+				return false;
+			}
+
+			i += run_len;
+		}
+	}
+
+	/* Some cables (e.g. UsbBlaster) buffer writeTMS()/writeTDI() output
+	 * internally and only push it over USB at specific points (buffer
+	 * full, or the start of the next writeTDI()). Without an explicit
+	 * flush here, whatever was queued by the last run of this XVC
+	 * "shift" transaction could still be sitting unsent when we reply
+	 * to Vivado -- leaving the real TAP state on the board out of sync
+	 * with what Vivado believes it just set. Force it out now. */
+	int ret = _jtag->flush();
+	if (ret < 0) {
+		printError("generic_writeTMSTDI: flush failed");
+		return false;
+	}
+
+	return true;
+}
+
 Jtag::tapState_t XVC_server::set_state(const uint8_t *tms_seq, uint32_t len)
 {
 	for (uint32_t i = 0; i < len; i++) {

--- a/src/xvc_server.hpp
+++ b/src/xvc_server.hpp
@@ -10,10 +10,11 @@
 #ifndef SRC_XVC_SERVER_HPP_
 #define SRC_XVC_SERVER_HPP_
 
-#include <netinet/in.h>
+#include "xvc_sockcompat.hpp"
 
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "jtag.hpp"
 
@@ -64,7 +65,7 @@ class XVC_server {
 		 * \return 2 when connection is closed, 1 when transactions fails,
 		 *         0 otherwise
 		 */
-		int handle_data(int fd);
+		int handle_data(SOCKET fd);
 		/*!
 		 * \brief read len bytes from client
 		 * \param fd: socket descriptor
@@ -72,12 +73,28 @@ class XVC_server {
 		 * \param len: number of bytes to read
 		 * \return 3 when failure, 2 when connection closed, 1 otherwise
 		 */
-		int sread(int fd, void *target, int len);
+		int sread(SOCKET fd, void *target, int len);
+		/*!
+		 * \brief software fallback for cables without a native
+		 *        writeTMSTDI(): decomposes the (tms, tdi) bit vector
+		 *        into runs and drives them through writeTMS() (pure
+		 *        TAP navigation runs) and writeTDI() (runs shifting
+		 *        through the current data register, tms held low
+		 *        except possibly the last bit of the run), both of
+		 *        which every cable is required to implement.
+		 * \param tms: array of TMS values, lsb first
+		 * \param tdi: array of TDI values, lsb first
+		 * \param tdo: array of TDO values (output), lsb first
+		 * \param len: number of bits to send/receive
+		 * \return true on success, false otherwise
+		 */
+		bool generic_writeTMSTDI(const uint8_t *tms, const uint8_t *tdi,
+			uint8_t *tdo, uint32_t len);
 
 	    int _verbose;          /*!< verbose level */
 		JtagInterface *_jtag;  /*!< jtag interface */
 		int _port;             /*!< network port */
-		int _sock;             /*!< server socket descriptor */
+		SOCKET _sock;          /*!< server socket descriptor */
 		struct sockaddr_in _sock_addr;
 		std::thread *_thread;  /*!< connection thread */
 		volatile bool _is_stopped;      /*!< true when thread is stopped */

--- a/src/xvc_sockcompat.hpp
+++ b/src/xvc_sockcompat.hpp
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2022 Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>
+ *
+ * Small portability shim used by xvc_client.* and xvc_server.* so the
+ * Xilinx Virtual Cable (XVC) code can be compiled both on POSIX systems
+ * (native BSD sockets) and on Windows (Winsock2), without scattering
+ * #ifdef _WIN32 blocks all over the XVC implementation files.
+ */
+
+#ifndef SRC_XVC_SOCKCOMPAT_HPP_
+#define SRC_XVC_SOCKCOMPAT_HPP_
+
+#include <string>
+
+#if defined(_WIN32) || defined(_WIN64)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+/* Winsock send()/recv() require char* buffers and have no read()/write()
+ * equivalent on raw SOCKET handles: wrap them so call sites stay identical
+ * on every platform. */
+#define xvc_close_socket(s)    closesocket(s)
+#define xvc_recv(fd, buf, len) recv((fd), reinterpret_cast<char *>(buf), \
+		static_cast<int>(len), 0)
+#define xvc_send(fd, buf, len) send((fd), reinterpret_cast<const char *>(buf), \
+		static_cast<int>(len), 0)
+
+/*!
+ * \brief initialize Winsock (no-op on POSIX)
+ * \return true on success
+ */
+inline bool xvc_socket_init()
+{
+	WSADATA wsaData;
+	return WSAStartup(MAKEWORD(2, 2), &wsaData) == 0;
+}
+
+/*!
+ * \brief release Winsock resources (no-op on POSIX)
+ */
+inline void xvc_socket_cleanup()
+{
+	WSACleanup();
+}
+
+/*!
+ * \brief return a human readable string for the last socket error
+ */
+inline std::string xvc_last_socket_error()
+{
+	return "WSA error " + std::to_string(WSAGetLastError());
+}
+
+#else  // POSIX
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+
+typedef int SOCKET;
+#define INVALID_SOCKET (-1)
+#define SOCKET_ERROR   (-1)
+
+#define xvc_close_socket(s)    close(s)
+#define xvc_recv(fd, buf, len) read((fd), (buf), (len))
+#define xvc_send(fd, buf, len) write((fd), (buf), (len))
+
+inline bool xvc_socket_init() { return true; }
+inline void xvc_socket_cleanup() {}
+
+inline std::string xvc_last_socket_error()
+{
+	return std::string(strerror(errno));
+}
+
+#endif  // _WIN32 || _WIN64
+
+#endif  // SRC_XVC_SOCKCOMPAT_HPP_


### PR DESCRIPTION
Enables XVC client and server in the Windows binary.
Adds support in the XVC server for USB-Blaster, CH347, and DirtyJTAG cables